### PR TITLE
Changed INLINE definition from inline to static inline in pdcscrn.c

### DIFF
--- a/win32a/pdcscrn.c
+++ b/win32a/pdcscrn.c
@@ -26,7 +26,7 @@ functions.        */
 #ifdef _MSC_VER
 #define INLINE static
 #else
-#define INLINE inline
+#define INLINE static inline
 #endif
 
 static int keep_size_within_bounds( int *lines, int *cols);


### PR DESCRIPTION
This fixes compilation failing on GCC 5.3.0 on MSYS2 when compiling with DEBUG defined.

The errors I received were as follows:
```
gcc -g -Wall -DPDCDEBUG -I.. -mwindows -otestcurs.exe ../demos/testcurs.c pdcurses.a -lgdi32 -lcomdlg32
pdcurses.a(pdcscrn.o): In function `final_cleanup':
..\PDCurses\win32a/../win32a/pdcscrn.c:109: undefined reference to `set_default_sizes_from_registry'
pdcurses.a(pdcscrn.o): In function `rectangle_from_chars_to_pixels':
...\PDCurses\win32a/../win32a/pdcscrn.c:779: undefined reference to `sort_out_rect'
pdcurses.a(pdcscrn.o): In function `WndProc':
...\PDCurses\win32a/../win32a/pdcscrn.c:1793: undefined reference to `HandleSizing'
...\PDCurses\win32a/../win32a/pdcscrn.c:1839: undefined reference to `HandleBlockCopy'
...\PDCurses\win32a/../win32a/pdcscrn.c:1994: undefined reference to `HandleMenuToggle'
...\PDCurses\win32a/../win32a/pdcscrn.c:2006: undefined reference to `show_mouse_rect'
...\PDCurses\win32a/../win32a/pdcscrn.c:2022: undefined reference to `milliseconds_since_1970'
pdcurses.a(pdcscrn.o): In function `PDC_scr_open':
...\PDCurses\win32a/../win32a/pdcscrn.c:2305: undefined reference to `set_up_window'
collect2.exe: error: ld returned 1 exit status
```

I haven't tried other platforms but if I've understood the semantics of static inline correctly I don't think this should break anything, it seems to me that static inline is the correct choice in exactly this case (function defined and used in the same translation unit and nowhere else).

As far as I understand it what gcc does here is when optimizations are turned off, it doesn't inline anything. And a bare inline without the static keyword indicates that the function may be defined externally so the inline version simply gets ignored. And because the function isn't declared elsewhere linking fails.