### PR TITLE
A couple Win32a changes

### DIFF
--- a/curses.h
+++ b/curses.h
@@ -1526,6 +1526,7 @@ void    PDC_set_resize_limits( const int new_min_lines,
                                const int new_max_lines,
                                const int new_min_cols,
                                const int new_max_cols);
+void    PDC_set_default_size( const int lines, const int cols);
 
 #define FUNCTION_KEY_SHUT_DOWN        0
 #define FUNCTION_KEY_PASTE            1

--- a/exp-base.def
+++ b/exp-base.def
@@ -375,3 +375,4 @@ tputs
 PDC_set_function_key
 Xinitscr
 PDC_set_resize_limits
+PDC_set_default_size

--- a/win32/pdcscrn.c
+++ b/win32/pdcscrn.c
@@ -687,6 +687,11 @@ void PDC_set_resize_limits( const int new_min_lines, const int new_max_lines,
 {
 }
 
+/* As above, added for Win32a, added here to avoid the unresolved */
+void PDC_set_default_size( const int lines, const int cols)
+{
+}
+
 /* PDC_set_function_key() does nothing on this platform */
 int PDC_set_function_key( const unsigned function, const int new_key)
 {

--- a/win32a/.gitignore
+++ b/win32a/.gitignore
@@ -3,3 +3,4 @@ trace
 *.exe
 *.obj
 *.lib
+*.ilk

--- a/win32a/.gitignore
+++ b/win32a/.gitignore
@@ -1,0 +1,5 @@
+none
+trace
+*.exe
+*.obj
+*.lib

--- a/win32a/pdcscrn.c
+++ b/win32a/pdcscrn.c
@@ -12,6 +12,8 @@ COLORREF *pdc_rgbs = (COLORREF *)NULL;
 static int menu_shown = 1;
 static int min_lines = 25, max_lines = 25;
 static int min_cols = 80, max_cols = 80;
+static int user_default_lines = 0;
+static int user_default_cols = 0;
 
 #if defined( CHTYPE_LONG) && CHTYPE_LONG >= 2 && defined( PDC_WIDE)
     #define USING_COMBINING_CHARACTER_SCHEME
@@ -1219,6 +1221,14 @@ void PDC_set_resize_limits( const int new_min_lines, const int new_max_lines,
     max_lines = max( new_max_lines, min_lines);
     min_cols = max( new_min_cols, 2);
     max_cols = max( new_max_cols, min_cols);
+    user_default_lines = max( min( user_default_lines, max_lines), min_lines);
+    user_default_cols = max( min( user_default_cols, max_cols), min_cols);
+}
+
+void PDC_set_default_size( const int lines, const int cols)
+{
+    user_default_lines = max( min( lines, max_lines), min_lines);
+    user_default_cols = max( min( cols, max_cols), min_cols);
 }
 
       /* The screen should hold the characters (PDC_cxChar * n_default_columns */
@@ -2134,8 +2144,8 @@ INLINE int set_up_window( void)
     WNDCLASS   wndclass ;
     HMENU hMenu;
     HANDLE hInstance = GetModuleHandleA( NULL);
-    int n_default_columns = 80;
-    int n_default_rows = 25;
+    int n_default_columns = ( user_default_cols > 0) ? user_default_cols : 80;
+    int n_default_rows = ( user_default_lines > 0) ? user_default_lines : 25;
     int xsize, ysize, window_style;
     int xloc = CW_USEDEFAULT;
     int yloc = CW_USEDEFAULT;
@@ -2183,6 +2193,7 @@ INLINE int set_up_window( void)
 
     get_default_sizes_from_registry( &n_default_columns, &n_default_rows, &xloc, &yloc,
                      &menu_shown);
+
     if( PDC_n_rows > 2 && PDC_n_cols > 2)
     {
         n_default_columns = PDC_n_cols;

--- a/win32a/pdcscrn.c
+++ b/win32a/pdcscrn.c
@@ -36,6 +36,8 @@ INLINE int set_default_sizes_from_registry( const int n_cols, const int n_rows,
                const int xloc, const int yloc, const int menu_shown);
 void PDC_transform_line_given_hdc( const HDC hdc, const int lineno,
                              int x, int len, const chtype *srcp);
+static void clip_or_center_window_to_monitor( HWND hwnd, UINT flags);
+static void clip_or_center_rect_to_monitor( LPRECT prc, UINT flags);
 
 #define N_COLORS 256
 
@@ -2118,6 +2120,54 @@ int PDC_set_function_key( const unsigned function, const int new_key)
     return( old_key);
 }
 
+#define MONITOR_CENTER   0x0001   /* center rect to monitor */
+#define MONITOR_CLIP     0x0000   /* clip rect to monitor */
+#define MONITOR_WORKAREA 0x0002   /* use monitor work area */
+#define MONITOR_AREA     0x0000   /* use monitor entire area */
+
+/* https://msdn.microsoft.com/en-us/library/windows/desktop/dd162826(v=vs.85).aspx */
+void clip_or_center_rect_to_monitor(LPRECT prc, UINT flags)
+{
+    HMONITOR hMonitor;
+    MONITORINFO mi;
+    RECT        rc;
+    int         w = prc->right  - prc->left;
+    int         h = prc->bottom - prc->top;
+
+    hMonitor = MonitorFromRect(prc, MONITOR_DEFAULTTONEAREST);
+
+    mi.cbSize = sizeof(mi);
+    GetMonitorInfo(hMonitor, &mi);
+
+    if (flags & MONITOR_WORKAREA)
+        rc = mi.rcWork;
+    else
+        rc = mi.rcMonitor;
+
+    if (flags & MONITOR_CENTER)
+    {
+        prc->left   = rc.left + (rc.right  - rc.left - w) / 2;
+        prc->top    = rc.top  + (rc.bottom - rc.top  - h) / 2;
+        prc->right  = prc->left + w;
+        prc->bottom = prc->top  + h;
+    }
+    else
+    {
+        prc->left   = max(rc.left, min(rc.right-w,  prc->left));
+        prc->top    = max(rc.top,  min(rc.bottom-h, prc->top));
+        prc->right  = prc->left + w;
+        prc->bottom = prc->top  + h;
+    }
+}
+
+void clip_or_center_window_to_monitor(HWND hwnd, UINT flags)
+{
+    RECT rc;
+    GetWindowRect(hwnd, &rc);
+    clip_or_center_rect_to_monitor(&rc, flags);
+    SetWindowPos(hwnd, NULL, rc.left, rc.top, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+}
+
 /* By default,  the user cannot resize the window.  This is because
 many apps don't handle KEY_RESIZE,  and one can get odd behavior
 in such cases.  There are two ways around this.  If you call
@@ -2224,14 +2274,6 @@ INLINE int set_up_window( void)
         adjust_window_size( &xsize, &ysize, window_style, menu_shown);
     }
 
-    /* if the window is off screen, move it somewhere visible */
-    int desktop_xsize = GetSystemMetrics( SM_CXVIRTUALSCREEN);
-    int desktop_ysize = GetSystemMetrics( SM_CYVIRTUALSCREEN);
-    if ( xloc < 0 || xloc > desktop_xsize || yloc < 0 || yloc > desktop_ysize)
-    {
-        xloc = yloc = 0;
-    }
-
     PDC_hWnd = CreateWindow( AppName, WindowTitle, window_style,
                     xloc, yloc,
                     xsize, ysize,
@@ -2260,6 +2302,10 @@ INLINE int set_up_window( void)
     debug_printf( "window updated\n");
     SetTimer( PDC_hWnd, TIMER_ID_FOR_BLINKING, 500, NULL);
     debug_printf( "timer set\n");
+
+    /* if the window is off-screen, move it on screen. */
+    clip_or_center_window_to_monitor( PDC_hWnd, MONITOR_WORKAREA);
+
     return( 0);
 }
 

--- a/win32a/pdcscrn.c
+++ b/win32a/pdcscrn.c
@@ -1223,8 +1223,11 @@ void PDC_set_resize_limits( const int new_min_lines, const int new_max_lines,
     max_lines = max( new_max_lines, min_lines);
     min_cols = max( new_min_cols, 2);
     max_cols = max( new_max_cols, min_cols);
-    user_default_lines = max( min( user_default_lines, max_lines), min_lines);
-    user_default_cols = max( min( user_default_cols, max_cols), min_cols);
+
+    if ( user_default_lines > 0 && user_default_cols > 0)
+    {
+        PDC_set_default_size( user_default_lines, user_default_cols);
+    }
 }
 
 void PDC_set_default_size( const int lines, const int cols)
@@ -2194,8 +2197,9 @@ INLINE int set_up_window( void)
     WNDCLASS   wndclass ;
     HMENU hMenu;
     HANDLE hInstance = GetModuleHandleA( NULL);
-    int n_default_columns = ( user_default_cols > 0) ? user_default_cols : 80;
-    int n_default_rows = ( user_default_lines > 0) ? user_default_lines : 25;
+    bool custom_default_size = ( user_default_cols > 0 && user_default_lines > 0);
+    int n_default_columns = custom_default_size ? user_default_cols : 80;
+    int n_default_rows = custom_default_size ? user_default_lines : 25;
     int xsize, ysize, window_style;
     int xloc = CW_USEDEFAULT;
     int yloc = CW_USEDEFAULT;

--- a/win32a/pdcscrn.c
+++ b/win32a/pdcscrn.c
@@ -2213,6 +2213,14 @@ INLINE int set_up_window( void)
         adjust_window_size( &xsize, &ysize, window_style, menu_shown);
     }
 
+    /* if the window is off screen, move it somewhere visible */
+    int desktop_xsize = GetSystemMetrics( SM_CXVIRTUALSCREEN);
+    int desktop_ysize = GetSystemMetrics( SM_CYVIRTUALSCREEN);
+    if ( xloc < 0 || xloc > desktop_xsize || yloc < 0 || yloc > desktop_ysize)
+    {
+        xloc = yloc = 0;
+    }
+
     PDC_hWnd = CreateWindow( AppName, WindowTitle, window_style,
                     xloc, yloc,
                     xsize, ysize,


### PR DESCRIPTION
Hi there! 

Not sure if you'd be interested in these changes, but figured I'd give you a pull request anyway.

Basically:

1. Added `PDC_set_default_size` in the same vain as `PDC_set_resize_limits`. Pattern matched implementation, including an empty method in the standard `Win32` variant. This allows us to set a custom default window size, instead of assuming 80x25. 

2. Fixed a bug with respect to restoring window size from registry values. If the user has a multi-monitor setup, and disables or repositions monitors, the main window may get stuck off screen. The fix uses some sample code from MSDN[1] to ensure the HWND is always on the screen.

[1] https://msdn.microsoft.com/en-us/library/windows/desktop/dd162826(v=vs.85).aspx 