### PR TITLE
Win32a multi-monitor support, take 2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+**/none
+**/trace
+**/*.exe
+**/*.obj
+**/*.lib
+**/*.ilk


### PR DESCRIPTION
Link to original pull request: https://github.com/Bill-Gray/PDCurses/pull/8

- Added auto-screen repositioning for multi-monitors based on an
MSDN example (links in source code).

- Added .gitignore to ignore compile artifacts.