### PR TITLE
Updated the way win32a's PDC_napms pumps the message queue.

### DIFF
--- a/win32a/pdcutil.c
+++ b/win32a/pdcutil.c
@@ -1,6 +1,7 @@
 /* Public Domain Curses */
 
 #include "pdcwin.h"
+#include "curses.h"
 
 void PDC_beep(void)
 {
@@ -15,23 +16,24 @@ void PDC_napms(int ms)     /* 'ms' = milli,  _not_ microseconds! */
 {
     /* RR: keep GUI window responsive while PDCurses sleeps */
     MSG msg;
-    DWORD milliseconds_sleep_limit = ms + GetTickCount();
+    DWORD start, end, delta;
     extern bool PDC_bDone;
 
-    PDC_LOG(("PDC_napms() - called: ms=%d\n", ms));
+    start = GetTickCount();
+
+    //PDC_LOG(("PDC_napms() - called: ms=%d\n", ms));
 
     /* Pump all pending messages from WIN32 to the window handler */
-    while( !PDC_bDone && GetTickCount() < milliseconds_sleep_limit )
+    while( !PDC_bDone && PeekMessage(&msg, NULL, 0, 0, PM_REMOVE) )
     {
-        while( PeekMessage(&msg, NULL, 0, 0, PM_REMOVE) )
-        {
-           TranslateMessage(&msg);
-           DispatchMessage(&msg);
-        }
-        Sleep(1);
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
     }
 
-    /* Sleep(ms); */
+    end = GetTickCount();
+    delta = end - start;
+    delta = ms > delta ? ms - delta : 0;
+    Sleep(delta);
 }
 
 const char *PDC_sysname(void)


### PR DESCRIPTION
Caution: merge with care! This is a potentially dangerous low-level change, but it's probably a good "heads up" at the very least. 

I spent some time looking at the performance of my app while "idle", that is, just waiting for input with a timeout of 5 milliseconds. In Process Explorer I noticed we were consuming a ton of CPU cycles -- about 65,000,000/period. (note: it's unclear what the period is here -- looks like a couple seconds -- but Process Explorer and Process Hacker numbers agree with each other).

I went poking around and discovered lots of cycles were being wasted with the way the win32 message pump was being drained. I switched around the logic to only pump the queue once per call to `PDC_napms`, then sleep the remaining duration (if required).

This reduced the number of cycles per period from ~65,000,000 to ~9,000,000 (in my app, measured using both Process Explorer and Process Hacker). This is still quite high, but a good improvement.

I've been playing with it for a few days now, and it doesn't seem to have any adverse effects.