### PR TITLE
Cleanup for `PDCEX` entries

### DIFF
--- a/exp-base.def
+++ b/exp-base.def
@@ -1,14 +1,18 @@
-LINES
-COLS
-stdscr
-curscr
-SP
-Mouse_status
-COLORS
-COLOR_PAIRS
-TABSIZE
-acs_map
-ttytype
+; entries that already have PDCEX in curses.h don't need another define
+; LINES
+; COLS
+; stdscr
+; curscr
+; SP
+; Mouse_status
+; COLORS
+; COLOR_PAIRS
+; TABSIZE
+; acs_map
+; ttytype
+; PDCEX entries from term.h
+; cur_term
+; ---------------------------------------------------------------------
 addch
 addchnstr
 addchstr
@@ -355,7 +359,6 @@ PDC_get_input_fd
 PDC_get_key_modifiers
 PDC_save_key_modifiers
 PDC_return_key_modifiers
-cur_term
 del_curterm
 putp
 restartterm

--- a/term.h
+++ b/term.h
@@ -20,15 +20,8 @@ typedef struct
     const char *_termname;
 } TERMINAL;
 
-#ifdef PDC_DLL_BUILD
-# ifndef CURSES_LIBRARY
-__declspec(dllimport)  TERMINAL *cur_term;
-# else
-__declspec(dllexport) extern TERMINAL *cur_term;
-# endif
-#else
-extern TERMINAL *cur_term;
-#endif
+/* PDCEX is defined in curses.h */
+PDCEX  TERMINAL *cur_term;
 
 int     del_curterm(TERMINAL *);
 int     putp(const char *);


### PR DESCRIPTION
These should not be part of the def files as they are `external`ized already:

* exp-base.def: comment the `PDCEX` entries out
* term.h: use `PDCEX` define from curses.h
