### PR TITLE
Added:Mouse handling to tuidemo

### DIFF
--- a/demos/tui.c
+++ b/demos/tui.c
@@ -22,6 +22,12 @@ void rmerror(void);
 #include <unistd.h>
 #endif
 
+#ifdef PDCURSES
+#define HAVE_CLIPBOARD
+#else
+#define nc_getmouse getmouse
+#endif
+
 #ifdef A_COLOR
 # define TITLECOLOR       1       /* color pair indices */
 # define MAINMENUCOLOR    (2 | A_BOLD)
@@ -609,7 +615,7 @@ void domenu(menu *mp)
             {
                 if((mouse_event.bstate & BUTTON1_PRESSED) || (mouse_event.bstate & BUTTON1_CLICKED))
                 {
-                    if( mouse_event.y <= th-1 )
+                    if( mouse_event.y <= th+1)
                     {
                         key = KEY_ESC; //exit menu
                         break;                      
@@ -621,7 +627,7 @@ void domenu(menu *mp)
                         break;
                                       
                     }
-                    else if((mouse_event.y > 0) &&  (mouse_event.y < y-1 || mouse_event.y > y-1) && (mouse_event.x > 0) && (mouse_event.x < x-1 || mouse_event.x > x-1))
+                    else if(mouse_event.y > 0 && mouse_event.y != y-1 && mouse_event.x > 0 && mouse_event.x != x-1)
                     {
                         key = KEY_ESC; //exit menu
                         break;

--- a/demos/tui.c
+++ b/demos/tui.c
@@ -865,7 +865,6 @@ int weditstr(WINDOW *win, char *buf, int field)
                                 }
                             }
                             break;
-#endif
                         default:
                              strcpy(buf, org);   /* restore original */
                              stop = TRUE;
@@ -875,7 +874,7 @@ int weditstr(WINDOW *win, char *buf, int field)
                 }
               }
             break;
-
+#endif
         case '\t':            /* TAB -- because insert
                                   is broken on HPUX */
         case KEY_IC:          /* enter insert mode */

--- a/demos/tui.c
+++ b/demos/tui.c
@@ -331,8 +331,14 @@ static void mainmenu(menu *mp)
                         for(int x = 1; x <= nitems ; ++x){
                             if((event.x > (barlen * (x-1)) && event.x < (barlen * x) ) &&
                                 (event.y == th )){
-                                cur = x-1;
-                                break;
+                                    if(x>=1){
+                                        cur = x-1;
+                                        break;
+                                    }
+                                    else{
+                                        key = KEY_ESC;
+                                        break;
+                                    }
                             }
                         }
                     }
@@ -601,25 +607,39 @@ void domenu(menu *mp)
             {
                 if((event.bstate & BUTTON1_PRESSED) || (event.bstate & BUTTON1_CLICKED))
                 {
-                    if((event.y - (y-1) > 0) &&  event.y > th && event.y <= y+mheight && event.x > x && event.x < mw +x){
+                    if( event.y <= th-1 )
+                    {
+                        key = KEY_ESC; //exit menu
+                        break;                      
+                    }
+                    else if((event.y - (y-1) > 0) &&  event.y > th && event.y <= y+mheight && event.x > x && event.x < mw +x)
+                    {
                         cur = (event.y - y-1) % nitems;
                         key = ERR;
-                    }else{
-                        key = KEY_ESC;
+                        break;
+                                      
                     }
-                    break;
+                    else if((event.y > 0) &&  (event.y < y-1 || event.y > y-1) && (event.x > 0) && (event.x < x-1 || event.x > x-1))
+                    {
+                        key = KEY_ESC; //exit menu
+                        break;
+                    }
+                        stop = TRUE;
+                        break;
                 }
-                if(event.bstate & BUTTON1_DOUBLE_CLICKED)
+                else if(event.bstate & BUTTON1_DOUBLE_CLICKED)
                 {
                     if((event.y - (y-1) > 0) &&  event.y > th && event.y <= y+mheight){
                          cur = (event.y - y-1) % nitems;
                          key = '\n';
+                         break;
                     }else{
                         key = KEY_ESC;
+                        break;
                     }
-                    break;
+                          
                 }
-                if( (event.bstate & BUTTON3_PRESSED) || (event.bstate & BUTTON3_CLICKED))
+                else if( (event.bstate & BUTTON3_PRESSED) || (event.bstate & BUTTON3_CLICKED))
                 {
                     key = KEY_ESC;
                     break;

--- a/demos/tui.c
+++ b/demos/tui.c
@@ -845,22 +845,15 @@ int weditstr(WINDOW *win, char *buf, int field)
                              c = KEY_ESC;
                             break;
                         case PDC_CLIP_SUCCESS:
-                            if ((int)strlen(ptr)){
-                                if (insert)  /* copy clip-board will work only in insert mode */
+                            if ((int)strlen(ptr) && insert){
+
+                                if ((int)strlen(buf) < field + 1  )
                                 {
-                                    if ((int)strlen(ptr) < field - 1)
-                                    {
-                                        memmove((void *)(ptr+(int)strlen(ptr)), (const void *)bp, (int)strlen(buf)+1); /* Experimental insert/add to existing text*/
-                                        strncpy(bp, ptr, (int)strlen(ptr));   /* copy clip-board to already existing field */
-                                        insert = !insert;
-                                        curs_set(insert ? 2 : 1);
-                                    }
-                                }
-                                else if (bp - ptr < field - 1)
-                                {
-                                    strncpy(bp, ptr, (int)(field - 1));   /* copy clip-board to already existing field */
-                                }
-                            while (bp - buf < (int)strlen(buf)){
+                                    memmove((void *)(ptr+(int)strlen(ptr)), (const void *)bp, (int)strlen(buf)+1); /* Experimental insert/add to existing text*/
+                                    strncpy(bp, ptr, field - (int)strlen(buf));   /* copy clip-board to already existing field */
+                                    insert = !insert;
+                                    curs_set(insert ? 2 : 1);
+                                while (bp - buf < (int)strlen(buf))
                                     bp++;
                                 }
                             }

--- a/demos/tui.c
+++ b/demos/tui.c
@@ -612,7 +612,7 @@ void domenu(menu *mp)
                         key = KEY_ESC; //exit menu
                         break;                      
                     }
-                    else if((event.y - (y-1) > 0) &&  event.y > th && event.y <= y+mheight && event.x > x && event.x < mw +x)
+                    else if((event.y - (y-1) > 0) &&  event.y > th && event.y < y+mheight && event.y > y && event.x > x && event.x < mw +x)
                     {
                         cur = (event.y - y-1) % nitems;
                         key = ERR;
@@ -629,7 +629,7 @@ void domenu(menu *mp)
                 }
                 else if(event.bstate & BUTTON1_DOUBLE_CLICKED)
                 {
-                    if((event.y - (y-1) > 0) &&  event.y > th && event.y <= y+mheight){
+                    if((event.y - (y-1) > 0) &&  event.y > th && event.y < y+mheight && event.y > y){
                          cur = (event.y - y-1) % nitems;
                          key = '\n';
                          break;

--- a/demos/tui.c
+++ b/demos/tui.c
@@ -22,12 +22,6 @@ void rmerror(void);
 #include <unistd.h>
 #endif
 
-#if defined( PDCURSES)
-   #define HAVE_CLIPBOARD 1
-#else
-   #define HAVE_CLIPBOARD 0
-#endif
-
 #ifdef A_COLOR
 # define TITLECOLOR       1       /* color pair indices */
 # define MAINMENUCOLOR    (2 | A_BOLD)
@@ -257,14 +251,18 @@ static void mainhelp(void)
 
 static void mainmenu(menu *mp)
 {
-    int nitems, barlen, old = -1, cur = 0, c, cur0;
+    int nitems, barlen, old = -1, cur = 0, c, cur0, x;
 
     menudim(mp, &nitems, &barlen);
     repaintmainmenu(barlen, mp);
-#if HAVE_CLIPBOARD
-    MEVENT event;
-    mousemask( BUTTON1_DOUBLE_CLICKED | BUTTON1_PRESSED | BUTTON1_CLICKED |BUTTON3_DOUBLE_CLICKED |BUTTON3_PRESSED |BUTTON3_CLICKED , NULL);
+    MEVENT mouse_event;
+#ifdef __PDCURSES__
+            nc_getmouse( &mouse_event);
+#else
+            getmouse( &mouse_event);
 #endif
+    mousemask( BUTTON1_DOUBLE_CLICKED | BUTTON1_PRESSED | BUTTON1_CLICKED |BUTTON3_DOUBLE_CLICKED |BUTTON3_PRESSED |BUTTON3_CLICKED , NULL);
+
     while (!quit)
     {
         if (cur != old)
@@ -322,15 +320,15 @@ static void mainmenu(menu *mp)
                 cur = (cur + 1) % nitems;
                 key = '\n';
                 break;
-#if HAVE_CLIPBOARD
+
             case KEY_MOUSE:
-                if(nc_getmouse(&event) == OK)
+                if(nc_getmouse(&mouse_event) == OK)
                 {
-                    if((event.bstate & BUTTON1_PRESSED) || (event.bstate & BUTTON1_DOUBLE_CLICKED) || (event.bstate & BUTTON1_CLICKED))
+                    if((mouse_event.bstate & BUTTON1_PRESSED) || (mouse_event.bstate & BUTTON1_DOUBLE_CLICKED) || (mouse_event.bstate & BUTTON1_CLICKED))
                     {
-                        for(int x = 1; x <= nitems ; ++x){
-                            if((event.x > (barlen * (x-1)) && event.x < (barlen * x) ) &&
-                                (event.y == th )){
+                        for( x = 1; x <= nitems ; ++x){
+                            if((mouse_event.x > (barlen * (x-1)) && mouse_event.x < (barlen * x) ) &&
+                                (mouse_event.y == th )){
                                     if(x>=1){
                                         cur = x-1;
                                         break;
@@ -345,7 +343,7 @@ static void mainmenu(menu *mp)
                         break;
                 }
                break;
-#endif
+
             default:
                 key = ERR;
             }
@@ -371,15 +369,15 @@ static void mainmenu(menu *mp)
         case KEY_ESC:
             mainhelp();
             break;
-#if HAVE_CLIPBOARD
+
         case KEY_MOUSE:
-            if(nc_getmouse(&event) == OK)
+            if(nc_getmouse(&mouse_event) == OK)
             {
-                if((event.bstate & BUTTON1_PRESSED) || (event.bstate & BUTTON1_DOUBLE_CLICKED) || (event.bstate & BUTTON1_CLICKED))
+                if((mouse_event.bstate & BUTTON1_PRESSED) || (mouse_event.bstate & BUTTON1_DOUBLE_CLICKED) || (mouse_event.bstate & BUTTON1_CLICKED))
                 {
-                    for(int x = 1; x <= nitems ; ++x){
-                        if((event.x > (barlen * (x-1)) && event.x < (barlen * x) ) &&
-                                (event.y == th)){
+                    for( x = 1; x <= nitems ; ++x){
+                        if((mouse_event.x > (barlen * (x-1)) && mouse_event.x < (barlen * x) ) &&
+                                (mouse_event.y == th)){
                             cur = x-1;
                             key = '\n';
                             break;
@@ -389,7 +387,7 @@ static void mainmenu(menu *mp)
                     break;
             }
            break;
-#endif
+
         default:
             cur0 = cur;
 
@@ -530,10 +528,14 @@ void domenu(menu *mp)
     repaintmenu(wmenu, mp);
 
     key = ERR;
-#if HAVE_CLIPBOARD
-    MEVENT event;
-    mousemask( BUTTON1_DOUBLE_CLICKED | BUTTON1_PRESSED | BUTTON1_CLICKED |BUTTON3_DOUBLE_CLICKED |BUTTON3_PRESSED |BUTTON3_CLICKED , NULL);
+    MEVENT mouse_event;	
+#ifdef __PDCURSES__
+            nc_getmouse( &mouse_event);
+#else
+            getmouse( &mouse_event);
 #endif
+    mousemask( BUTTON1_DOUBLE_CLICKED | BUTTON1_PRESSED | BUTTON1_CLICKED |BUTTON3_DOUBLE_CLICKED |BUTTON3_PRESSED |BUTTON3_CLICKED , NULL);
+
     while (!stop && !quit)
     {
         if (cur != old)
@@ -601,25 +603,25 @@ void domenu(menu *mp)
 
             stop = TRUE;
             break;
-#if HAVE_CLIPBOARD
+
         case KEY_MOUSE:
-            if(nc_getmouse(&event) == OK)
+            if(nc_getmouse(&mouse_event) == OK)
             {
-                if((event.bstate & BUTTON1_PRESSED) || (event.bstate & BUTTON1_CLICKED))
+                if((mouse_event.bstate & BUTTON1_PRESSED) || (mouse_event.bstate & BUTTON1_CLICKED))
                 {
-                    if( event.y <= th-1 )
+                    if( mouse_event.y <= th-1 )
                     {
                         key = KEY_ESC; //exit menu
                         break;                      
                     }
-                    else if((event.y - (y-1) > 0) &&  event.y > th && event.y < y+mheight && event.y > y && event.x > x && event.x < mw +x)
+                    else if((mouse_event.y - (y-1) > 0) &&  mouse_event.y > th && mouse_event.y < y+mheight && mouse_event.y > y && mouse_event.x > x && mouse_event.x < mw +x)
                     {
-                        cur = (event.y - y-1) % nitems;
+                        cur = (mouse_event.y - y-1) % nitems;
                         key = ERR;
                         break;
                                       
                     }
-                    else if((event.y > 0) &&  (event.y < y-1 || event.y > y-1) && (event.x > 0) && (event.x < x-1 || event.x > x-1))
+                    else if((mouse_event.y > 0) &&  (mouse_event.y < y-1 || mouse_event.y > y-1) && (mouse_event.x > 0) && (mouse_event.x < x-1 || mouse_event.x > x-1))
                     {
                         key = KEY_ESC; //exit menu
                         break;
@@ -627,10 +629,10 @@ void domenu(menu *mp)
                         stop = TRUE;
                         break;
                 }
-                else if(event.bstate & BUTTON1_DOUBLE_CLICKED)
+                else if(mouse_event.bstate & BUTTON1_DOUBLE_CLICKED)
                 {
-                    if((event.y - (y-1) > 0) &&  event.y > th && event.y < y+mheight && event.y > y){
-                         cur = (event.y - y-1) % nitems;
+                    if((mouse_event.y - (y-1) > 0) &&  mouse_event.y > th && mouse_event.y < y+mheight && mouse_event.y > y){
+                         cur = (mouse_event.y - y-1) % nitems;
                          key = '\n';
                          break;
                     }else{
@@ -639,14 +641,14 @@ void domenu(menu *mp)
                     }
                           
                 }
-                else if( (event.bstate & BUTTON3_PRESSED) || (event.bstate & BUTTON3_CLICKED))
+                else if( (mouse_event.bstate & BUTTON3_PRESSED) || (mouse_event.bstate & BUTTON3_CLICKED))
                 {
                     key = KEY_ESC;
                     break;
                 }
             }
             break;
-#endif
+
         default:
             cur0 = cur;
 
@@ -754,9 +756,16 @@ int weditstr(WINDOW *win, char *buf, int field)
     chtype oldattr;
     WINDOW *wedit;
     int c = 0;
-#if HAVE_CLIPBOARD
+#ifdef HAVE_CLIPBOARD
     char *ptr = NULL;
     long j, length = 0;
+    MEVENT mouse_event;
+#ifdef __PDCURSES__
+            nc_getmouse( &mouse_event);
+#else
+            getmouse( &mouse_event);
+#endif
+    mousemask( BUTTON1_DOUBLE_CLICKED | BUTTON1_PRESSED | BUTTON1_CLICKED |BUTTON3_DOUBLE_CLICKED |BUTTON3_PRESSED |BUTTON3_CLICKED , NULL);
 #endif
     if ((field >= MAXSTRLEN) || (buf == NULL) ||
         ((int)strlen(buf) > field - 1))
@@ -774,10 +783,7 @@ int weditstr(WINDOW *win, char *buf, int field)
 
     keypad(wedit, TRUE);
     curs_set(1);
-#if HAVE_CLIPBOARD
-    MEVENT event;
-    mousemask( BUTTON1_DOUBLE_CLICKED | BUTTON1_PRESSED | BUTTON1_CLICKED |BUTTON3_DOUBLE_CLICKED |BUTTON3_PRESSED |BUTTON3_CLICKED , NULL);
-#endif
+
     while (!stop)
     {
         idle();
@@ -821,13 +827,13 @@ int weditstr(WINDOW *win, char *buf, int field)
             if (bp - buf < (int)strlen(buf))
                 bp++;
             break;
-#if HAVE_CLIPBOARD
+#ifdef HAVE_CLIPBOARD
         case KEY_MOUSE:
-            if(nc_getmouse(&event) == OK)
+            if(nc_getmouse(&mouse_event) == OK)
             {
-                 if(event.bstate & BUTTON1_DOUBLE_CLICKED){
-                     if(event.y >= begy + cury &&  event.y <= begy + cury + 1 &&
-                             event.x >= begx + curx &&  event.x <= begx + curx +  field){
+                 if(mouse_event.bstate & BUTTON1_DOUBLE_CLICKED){
+                     if(mouse_event.y >= begy + cury &&  mouse_event.y <= begy + cury + 1 &&
+                             mouse_event.x >= begx + curx &&  mouse_event.x <= begx + curx +  field){
                             c = KEY_DOWN;
                             stop = TRUE;
                             break;
@@ -838,13 +844,13 @@ int weditstr(WINDOW *win, char *buf, int field)
                             break;
                      }
                  }
-                 else if(event.bstate & BUTTON3_DOUBLE_CLICKED){
+                 else if(mouse_event.bstate & BUTTON3_DOUBLE_CLICKED){
                             c = KEY_UP;
                             strcpy(buf, org);   /* restore original */
                             stop = TRUE;
                             break;
                  }
-                 else if( (event.bstate & BUTTON3_PRESSED) || (event.bstate & BUTTON3_CLICKED))
+                 else if( (mouse_event.bstate & BUTTON3_PRESSED) || (mouse_event.bstate & BUTTON3_CLICKED))
                  {
                     j = PDC_getclipboard(&ptr, &length);
                     switch(j)


### PR DESCRIPTION
Added:Mouse handling to tuidemo regarding menus,sub-menus&dialogs
as per request in https://github.com/Bill-Gray/PDCurses/issues/35

This patch include, open a menu ,close a menu and paste text from the mouse clipboard to the sub-fields of the tuidemo.

Notes;
1) The mouse clipboard will work only by activating insert mode [KEY_IC/KEY_EIC] on the keyboard and by using the right click button of the mouse to paste one string of text.

2) Clicking or double clicking outside the current opened menu will be considered as [KEY_ESC].

3) One click to highlight the chosen menu.

4) Double clicking on the highlighted menu to open it.