### PR TITLE
Allow cross-compile for dos from GNU/Linux

### DIFF
--- a/dos/gccdos.mak
+++ b/dos/gccdos.mak
@@ -1,11 +1,13 @@
 # GNU MAKE (3.79.1) Makefile for PDCurses library - DOS DJGPP V2.0+
 #
-# Usage: make -f [path\]gccdos.mak [DEBUG=Y] [CROSS] [target]
+# Usage: make -f [path\]gccdos.mak [DEBUG=Y] [CROSS=[build]] [target]
 #
-# where target can be any of:
+# where "target" can be any of:
 # [all|libs|demos|dist|pdcurses.a|testcurs.exe...]
 #
-# Note: when cross-compiling from GNU/Linux set [CROSS]
+# and "build" any installed cross-compiler (gcc + binutils),
+#  CROSS=Y defaults to i586-pc-msdosdjgpp build
+# Note: when cross-compiling from GNU/Linux set CROSS=Y even for make clean
 
 O = o
 
@@ -20,14 +22,20 @@ osdir		= $(PDCURSES_SRCDIR)/dos
 
 PDCURSES_DOS_H	= $(osdir)/pdcdos.h
 
-CC		= gcc
+ifndef CROSS
+	COPY	= copy
+	DEL		= del
+else
+	COPY	= cp
+	DEL		= rm -rf
+endif
 
 ifeq ($(CROSS),Y)
-	COPY	= cp
-	DEL 	= rm -rf
+	PREFIX	= i586-pc-msdosdjgpp-
 else
-	COPY	= copy
-	DEL 	= del
+	ifdef CROSS
+		PREFIX	= $(CROSS)-
+	endif
 endif
 
 ifeq ($(DEBUG),Y)
@@ -40,9 +48,11 @@ endif
 
 CFLAGS += -I$(PDCURSES_SRCDIR)
 
-LINK		= gcc
 
-LIBEXE		= ar
+CC		= $(PREFIX)gcc
+LINK		= $(PREFIX)gcc
+
+LIBEXE		= $(PREFIX)ar
 LIBFLAGS	= rcv
 
 LIBCURSES	= pdcurses.a
@@ -59,7 +69,7 @@ clean:
 	-$(DEL) *.exe
 
 demos:	$(DEMOS)
-	strip *.exe
+	$(PREFIX)strip *.exe
 
 $(LIBCURSES) : $(LIBOBJS) $(PDCOBJS)
 	$(LIBEXE) $(LIBFLAGS) $@ $?

--- a/dos/gccdos.mak
+++ b/dos/gccdos.mak
@@ -71,7 +71,9 @@ clean:
 demos:	$(DEMOS)
 	$(PREFIX)strip *.exe
 
-$(LIBCURSES) : $(LIBOBJS) $(PDCOBJS)
+# note: we always want the system specific objects to be first
+#       as these are most likely to raise compiler issues 
+$(LIBCURSES) : $(PDCOBJS) $(LIBOBJS)
 	$(LIBEXE) $(LIBFLAGS) $@ $?
 	-$(COPY) $(LIBCURSES) panel.a
 

--- a/dos/gccdos.mak
+++ b/dos/gccdos.mak
@@ -1,9 +1,11 @@
 # GNU MAKE (3.79.1) Makefile for PDCurses library - DOS DJGPP V2.0+
 #
-# Usage: make -f [path\]gccdos.mak [DEBUG=Y] [target]
+# Usage: make -f [path\]gccdos.mak [DEBUG=Y] [CROSS] [target]
 #
 # where target can be any of:
 # [all|libs|demos|dist|pdcurses.a|testcurs.exe...]
+#
+# Note: when cross-compiling from GNU/Linux set [CROSS]
 
 O = o
 
@@ -19,6 +21,14 @@ osdir		= $(PDCURSES_SRCDIR)/dos
 PDCURSES_DOS_H	= $(osdir)/pdcdos.h
 
 CC		= gcc
+
+ifeq ($(CROSS),Y)
+	COPY	= cp
+	DEL 	= rm -rf
+else
+	COPY	= copy
+	DEL 	= del
+endif
 
 ifeq ($(DEBUG),Y)
 	CFLAGS  = -g -Wall -DPDCDEBUG
@@ -44,16 +54,16 @@ all:	libs demos
 libs:	$(LIBCURSES)
 
 clean:
-	-del *.o
-	-del *.a
-	-del *.exe
+	-$(DEL) *.o
+	-$(DEL) *.a
+	-$(DEL) *.exe
 
 demos:	$(DEMOS)
 	strip *.exe
 
 $(LIBCURSES) : $(LIBOBJS) $(PDCOBJS)
 	$(LIBEXE) $(LIBFLAGS) $@ $?
-	-copy $(LIBCURSES) panel.a
+	-$(COPY) $(LIBCURSES) panel.a
 
 $(LIBOBJS) $(PDCOBJS) : $(PDCURSES_HEADERS)
 $(PDCOBJS) : $(PDCURSES_DOS_H)

--- a/dos/pdcutil.c
+++ b/dos/pdcutil.c
@@ -44,7 +44,7 @@ const char *PDC_sysname(void)
     return "DOS";
 }
 
-PDCEX PDC_version_info PDC_version = { PDC_PORT_DOS,
+PDC_version_info PDC_version = { PDC_PORT_DOS,
           PDC_VER_MAJOR, PDC_VER_MINOR, PDC_VER_CHANGE,
           sizeof( chtype),
                /* note that thus far,  'wide' and 'UTF8' versions exist */


### PR DESCRIPTION
As my time machine doesn't work I've setup FreeDOS which includes DJGPP GCC 4.7 where I wanted to *use* a nice piece of software that needs to run configure (or a lot of hand work) to be build and has non 8.3 files that aren't easily to transfer/compile in FreeDOS.
Therefore I've created an i586-pc-msdosdjgpp cross compilation environment on my Trisquel box and tried to use gccdos.mak (after manually setting activating the i586-pc-msdosdjgpp environment) to compile PDCurses. And it mostly worked.

The minimal needed changes are part of the current PR, if there's any interest in this I'll add the  `i586-pc-msdosdjgpp-` prefix for the tools and try to do a fresh compile without any manual setup.

@Bill-Gray: What do you think?

BTW: As the ftpserver refuses to work in my FreeDOS environment I've `apt-get install dosbox` to check if the demos work - and they actually do :-)
[I've not yet succeeded in linking the resulting static library to the other software, the linker can't find it, will retry with a hard LDFLAGS setting and assume it will work]