### PR TITLE
Patch to fix corner cases in PDC_napms(.) for DOS, and allow cross-compiling with Open Watcom

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,7 +7,8 @@ Major new features:
 
 Minor new features 
 -------------------
-- dos variant: cross-compilation from GNU/Linux
+- dos variant: cross-compilation from GNU/Linux works with both DJGPP and
+  16-bit Watcom C/C++
 
 Bugfixes
 -------------------
@@ -16,6 +17,9 @@ Bugfixes
 - newtest sample was broken in all widw variants #60
 
 - the paste button printed debug output #62
+
+- some corner cases (midnight crossing, atomicity of tick count reads) in
+  DOS version of napms() were not handled well
 
 PDCurses 4.0.2 - 2017/09/12
 =========================

--- a/curspriv.h
+++ b/curspriv.h
@@ -126,7 +126,7 @@ size_t  PDC_wcstombs(char *, const wchar_t *, size_t);
 # define min(a,b) (((a) < (b)) ? (a) : (b))
 #endif
 
-#define DIVROUND(num, divisor) ((num) + ((divisor) >> 1)) / (divisor)
+#define DIVROUND(num, divisor) (((num) + ((divisor) >> 1)) / (divisor))
 
 #define PDC_CLICK_PERIOD 150  /* time to wait for a click, if
                                  not set by mouseinterval() */

--- a/dos/pdcutil.c
+++ b/dos/pdcutil.c
@@ -104,8 +104,15 @@ void PDC_napms(int ms)
 
     while (goal > (current = irq0_ticks()))
     {
-        if (current < start)    /* this should really not happen */
-            return;
+        if (current < start)
+        {
+            /* If the BIOS time somehow gets reset under us (ugh!), then
+               restart (what is left of) the nap with `current' as the new
+               starting time.  Remember to adjust the goal time
+               accordingly!  */
+            goal -= start - current;
+            start = current;
+        }
 
         do_idle();
     }

--- a/dos/pdcutil.c
+++ b/dos/pdcutil.c
@@ -22,7 +22,7 @@ void PDC_beep(void)
    tick count with a carry over from the lower half to the upper half ---
    and our read count will be bogus.  */
 #elif defined __TURBOC__
-unsigned long irq0_ticks(void)
+static unsigned long irq0_ticks(void)
 {
     unsigned long t;
     disable();
@@ -31,7 +31,7 @@ unsigned long irq0_ticks(void)
     return t;
 }
 #elif defined __WATCOMC__
-unsigned long irq0_ticks(void)
+static unsigned long irq0_ticks(void)
 {
     unsigned long t;
     _disable();
@@ -98,6 +98,8 @@ void PDC_napms(int ms)
 
         while (irq0_ticks() > start)
             do_idle();
+
+        start = 0;
     }
 
     while (goal > (current = irq0_ticks()))

--- a/dos/pdcutil.c
+++ b/dos/pdcutil.c
@@ -66,7 +66,7 @@ void PDC_napms(int ms)
 
 #if INT_MAX > MS_PER_DAY / 2
     /* If `int' is 32-bit, we might be asked to "nap" for more than one day,
-       in which case the system timer might wrap around at least once, and
+       in which case the system timer might wrap around at least twice, and
        that will be tricky to handle as is.  Slice the "nap" into half-day
        portions.  */
     while (ms > MS_PER_DAY / 2)

--- a/dos/wccdos16.mak
+++ b/dos/wccdos16.mak
@@ -32,51 +32,37 @@ CROSS_COMPILE	= Y
 !endif
 !endif
 
-!ifeq CROSS_COMPILE Y
 osdir		= $(PDCURSES_SRCDIR)/dos
-# OpenWatcom README strongly recommends setting WATCOM environment variable...
+# Open Watcom README strongly recommends setting WATCOM environment variable...
+!ifeq CROSS_COMPILE Y
 !ifdef %WATCOM
 watcomdir	= $(%WATCOM)
 !else
 watcomdir	= "`which wcc | xargs realpath | xargs dirname`"/..
 !endif
-!else
-osdir		= $(PDCURSES_SRCDIR)\dos
 !endif
 
 CC		= wcc
 TARGET		= dos
 
-!ifeq CROSS_COMPILE Y
 CFLAGS		= -bt=$(TARGET) -zq -wx -m$(MODEL) -i=$(PDCURSES_SRCDIR)
+# the README also recommends setting INCLUDE; if absent, we need an extra -i=
+!ifndef %INCLUDE
 CFLAGS		+= -i=$(watcomdir)/h
-!else
-CFLAGS		= /bt=$(TARGET) /zq /wx /m$(MODEL) /i=$(PDCURSES_SRCDIR)
 !endif
 
 !ifeq DEBUG Y
-!ifeq CROSS_COMPILE Y
 CFLAGS  	+= -d2 -DPDCDEBUG
-!else
-CFLAGS  	+= /d2 /DPDCDEBUG
-!endif
 LDFLAGS 	= D W A op q sys $(TARGET)
 !else
-!ifeq CROSS_COMPILE Y
 CFLAGS  	+= -oneatx
 LDFLAGS		= op q sys $(TARGET)
+!ifeq CROSS_COMPILE Y
 LDFLAGS 	+= libp $(watcomdir)/lib286/dos\;$(watcomdir)/lib286
-!else
-CFLAGS  	+= /oneatx
-LDFLAGS 	= op q sys $(TARGET)
 !endif
 !endif
 
-!ifeq CROSS_COMPILE Y
 LIBEXE		= wlib -q -n -t
-!else
-LIBEXE		= wlib /q /n /t
-!endif
 
 !include $(PDCURSES_SRCDIR)/watcom.mif
 

--- a/dos/wccdos16.mak
+++ b/dos/wccdos16.mak
@@ -14,35 +14,85 @@ PDCURSES_SRCDIR	= $(%PDCURSES_SRCDIR)
 PDCURSES_SRCDIR	= ..
 !endif
 
-!include $(PDCURSES_SRCDIR)\version.mif
+!include $(PDCURSES_SRCDIR)/version.mif
 
+!ifndef CROSS_COMPILE
+!ifeq %SHELL /bin/bash
+# assume we are cross-compiling
+CROSS_COMPILE	= Y
+!endif
+!ifeq %SHELL /bin/sh
+CROSS_COMPILE	= Y
+!endif
+!ifeq %SHELL /bin/csh
+CROSS_COMPILE	= Y
+!endif
+!ifeq %SHELL /bin/dash
+CROSS_COMPILE	= Y
+!endif
+!endif
+
+!ifeq CROSS_COMPILE Y
+osdir		= $(PDCURSES_SRCDIR)/dos
+# OpenWatcom README strongly recommends setting WATCOM environment variable...
+!ifdef %WATCOM
+watcomdir	= $(%WATCOM)
+!else
+watcomdir	= "`which wcc | xargs realpath | xargs dirname`"/..
+!endif
+!else
 osdir		= $(PDCURSES_SRCDIR)\dos
+!endif
 
 CC		= wcc
 TARGET		= dos
 
+!ifeq CROSS_COMPILE Y
+CFLAGS		= -bt=$(TARGET) -zq -wx -m$(MODEL) -i=$(PDCURSES_SRCDIR)
+CFLAGS		+= -i=$(watcomdir)/h
+!else
 CFLAGS		= /bt=$(TARGET) /zq /wx /m$(MODEL) /i=$(PDCURSES_SRCDIR)
+!endif
 
 !ifeq DEBUG Y
+!ifeq CROSS_COMPILE Y
+CFLAGS  	+= -d2 -DPDCDEBUG
+!else
 CFLAGS  	+= /d2 /DPDCDEBUG
+!endif
 LDFLAGS 	= D W A op q sys $(TARGET)
+!else
+!ifeq CROSS_COMPILE Y
+CFLAGS  	+= -oneatx
+LDFLAGS		= op q sys $(TARGET)
+LDFLAGS 	+= libp $(watcomdir)/lib286/dos\;$(watcomdir)/lib286
 !else
 CFLAGS  	+= /oneatx
 LDFLAGS 	= op q sys $(TARGET)
 !endif
+!endif
 
+!ifeq CROSS_COMPILE Y
+LIBEXE		= wlib -q -n -t
+!else
 LIBEXE		= wlib /q /n /t
+!endif
 
-!include $(PDCURSES_SRCDIR)\watcom.mif
+!include $(PDCURSES_SRCDIR)/watcom.mif
 
 $(LIBCURSES) : $(LIBOBJS) $(PDCOBJS)
 	%write wccdos.lrf $(LIBOBJS) $(PDCOBJS)
 	$(LIBEXE) $@ @wccdos.lrf
+!ifeq CROSS_COMPILE Y
+	rm wccdos.lrf
+	cp $(LIBCURSES) panel.lib
+!else
 	-del wccdos.lrf
 	-copy $(LIBCURSES) panel.lib
+!endif
 
 PLATFORM1	= Watcom C++ 16-bit DOS
 PLATFORM2	= Open Watcom 1.6 for 16-bit DOS
 ARCNAME		= pdc$(VER)16w
 
-!include $(PDCURSES_SRCDIR)\makedist.mif
+!include $(PDCURSES_SRCDIR)/makedist.mif

--- a/dos/wccdos16.mak
+++ b/dos/wccdos16.mak
@@ -1,12 +1,20 @@
 # Watcom WMAKE Makefile for PDCurses library - DOS (16 bit) Watcom C/C++ 10.6+
 #
-# Usage: wmake -f [path\]wccdos16.mak [DEBUG=Y] [target]
+# Usage: wmake -f [path/]wccdos16.mak [DEBUG=Y] [CROSS=Y|N]
+#        [MODEL=c|h|l|m|s] [target]
 #
 # where target can be any of:
 # [all|demos|pdcurses.lib|testcurs.exe...]
+#
+# and MODEL specifies the memory model (compact/huge/large/medium/small)
+#
+# and CROSS=Y (CROSS=N) means to assume we are (are not) cross-compiling
+# (default is to auto-detect)
 
 # Change the memory MODEL here, if desired
+!ifndef MODEL
 MODEL		= l
+!endif
 
 !ifdef %PDCURSES_SRCDIR
 PDCURSES_SRCDIR	= $(%PDCURSES_SRCDIR)
@@ -16,25 +24,25 @@ PDCURSES_SRCDIR	= ..
 
 !include $(PDCURSES_SRCDIR)/version.mif
 
-!ifndef CROSS_COMPILE
+!ifndef CROSS
 !ifeq %SHELL /bin/bash
 # assume we are cross-compiling
-CROSS_COMPILE	= Y
+CROSS		= Y
 !endif
 !ifeq %SHELL /bin/sh
-CROSS_COMPILE	= Y
+CROSS		= Y
 !endif
 !ifeq %SHELL /bin/csh
-CROSS_COMPILE	= Y
+CROSS		= Y
 !endif
 !ifeq %SHELL /bin/dash
-CROSS_COMPILE	= Y
+CROSS		= Y
 !endif
 !endif
 
 osdir		= $(PDCURSES_SRCDIR)/dos
 # Open Watcom README strongly recommends setting WATCOM environment variable...
-!ifeq CROSS_COMPILE Y
+!ifeq CROSS Y
 !ifdef %WATCOM
 watcomdir	= $(%WATCOM)
 !else
@@ -57,7 +65,7 @@ LDFLAGS 	= D W A op q sys $(TARGET)
 !else
 CFLAGS  	+= -oneatx
 LDFLAGS		= op q sys $(TARGET)
-!ifeq CROSS_COMPILE Y
+!ifeq CROSS Y
 LDFLAGS 	+= libp $(watcomdir)/lib286/dos\;$(watcomdir)/lib286
 !endif
 !endif
@@ -69,13 +77,8 @@ LIBEXE		= wlib -q -n -t
 $(LIBCURSES) : $(LIBOBJS) $(PDCOBJS)
 	%write wccdos.lrf $(LIBOBJS) $(PDCOBJS)
 	$(LIBEXE) $@ @wccdos.lrf
-!ifeq CROSS_COMPILE Y
-	rm wccdos.lrf
-	cp $(LIBCURSES) panel.lib
-!else
-	-del wccdos.lrf
-	-copy $(LIBCURSES) panel.lib
-!endif
+	-$(DEL) wccdos.lrf
+	-$(COPY) $(LIBCURSES) panel.lib
 
 PLATFORM1	= Watcom C++ 16-bit DOS
 PLATFORM2	= Open Watcom 1.6 for 16-bit DOS

--- a/watcom.mif
+++ b/watcom.mif
@@ -1,12 +1,7 @@
 # Common elements for the Watcom makefiles
 
-!ifeq CROSS_COMPILE Y
 srcdir = $(PDCURSES_SRCDIR)/pdcurses
 demodir = $(PDCURSES_SRCDIR)/demos
-!else
-srcdir = $(PDCURSES_SRCDIR)\pdcurses
-demodir = $(PDCURSES_SRCDIR)\demos
-!endif
 
 LIBOBJS = addch.obj addchstr.obj addstr.obj attr.obj beep.obj bkgd.obj &
 border.obj clear.obj color.obj delch.obj deleteln.obj deprec.obj &
@@ -49,11 +44,7 @@ demos:	$(DEMOS)
 
 .c: $(srcdir);$(osdir);$(demodir)
 .c.obj: .autodepend
-!ifeq CROSS_COMPILE Y
 	$(CC) $(CFLAGS) -fo=$@ $<
-!else
-	$(CC) $(CFLAGS) $<
-!endif
 
 .obj.exe:
 	$(LINK) $(LDFLAGS) n $@ f $*.obj l $(LIBCURSES)

--- a/watcom.mif
+++ b/watcom.mif
@@ -1,5 +1,13 @@
 # Common elements for the Watcom makefiles
 
+!ifeq CROSS Y
+DEL		= rm -f
+COPY		= cp
+!else
+DEL		= del
+COPY		= copy
+!endif
+
 srcdir = $(PDCURSES_SRCDIR)/pdcurses
 demodir = $(PDCURSES_SRCDIR)/demos
 
@@ -31,14 +39,10 @@ LINK = wlink
 all:	$(LIBCURSES) $(DEMOS)
 
 clean
-!ifeq CROSS_COMPILE Y
-	rm -f *.obj *.lib *.exe *.err
-!else
-	-del *.obj
-	-del *.lib
-	-del *.exe
-	-del *.err
-!endif
+	-$(DEL) *.obj
+	-$(DEL) *.lib
+	-$(DEL) *.exe
+	-$(DEL) *.err
 
 demos:	$(DEMOS)
 

--- a/watcom.mif
+++ b/watcom.mif
@@ -1,7 +1,12 @@
 # Common elements for the Watcom makefiles
 
+!ifeq CROSS_COMPILE Y
+srcdir = $(PDCURSES_SRCDIR)/pdcurses
+demodir = $(PDCURSES_SRCDIR)/demos
+!else
 srcdir = $(PDCURSES_SRCDIR)\pdcurses
 demodir = $(PDCURSES_SRCDIR)\demos
+!endif
 
 LIBOBJS = addch.obj addchstr.obj addstr.obj attr.obj beep.obj bkgd.obj &
 border.obj clear.obj color.obj delch.obj deleteln.obj deprec.obj &
@@ -40,7 +45,11 @@ demos:	$(DEMOS)
 
 .c: $(srcdir);$(osdir);$(demodir)
 .c.obj: .autodepend
+!ifeq CROSS_COMPILE Y
+	$(CC) $(CFLAGS) -fo=$@ $<
+!else
 	$(CC) $(CFLAGS) $<
+!endif
 
 .obj.exe:
 	$(LINK) $(LDFLAGS) n $@ f $*.obj l $(LIBCURSES)

--- a/watcom.mif
+++ b/watcom.mif
@@ -36,10 +36,14 @@ LINK = wlink
 all:	$(LIBCURSES) $(DEMOS)
 
 clean
+!ifeq CROSS_COMPILE Y
+	rm -f *.obj *.lib *.exe *.err
+!else
 	-del *.obj
 	-del *.lib
 	-del *.exe
 	-del *.err
+!endif
 
 demos:	$(DEMOS)
 


### PR DESCRIPTION
Here is a proposed patch to `dos/pdcutil.c` which fixes `PDC_napms(.)` to correctly handle a few corner cases, namely
  * where an extremely long sleep length is requested (possible with 32-bit DOS extenders);
  * where a sleep request crosses midnight;
  * where, between reading the two shortwords in the timer tick count (`0:0x46c`), a timer interrupt occurs.

In addition, I have (hopefully) improved the accuracy of converting from milliseconds to ticks.

While I was at it, I also modified `dos/wccdos16.mak` and `watcom.mif`, so that they can now work with Open Watcom C/C++ 2.0 to cross-compile DOS code from Linux.

Thank you!