### PR TITLE
Allow compilation with both MinGW and mingw-64

### DIFF
--- a/win32/mingwin32.mak
+++ b/win32/mingwin32.mak
@@ -90,6 +90,14 @@ ifeq ($(UTF8),Y)
 	CFLAGS += -DPDC_FORCE_UTF8
 endif
 
+ifeq ($(INFOEX),N)
+	PDCCFLAGS += -DHAVE_NO_INFOEX
+else
+	ifeq ($(INFOEX),Y)
+		PDCCFLAGS += -DHAVE_INFOEX
+	endif
+endif
+
 LINK	   = $(PREFIX)gcc
 
 ifeq ($(DLL),Y)
@@ -146,7 +154,7 @@ $(LIBOBJS) : %.o: $(srcdir)/%.c
 	$(CC) -c $(CFLAGS) $<
 
 $(PDCOBJS) : %.o: $(osdir)/%.c
-	$(CC) -c $(CFLAGS) $<
+	$(CC) -c $(CFLAGS) $(PDCCFLAGS) $<
 
 firework.exe newdemo.exe newtest.exe ptest.exe rain.exe testcurs.exe  \
 version.exe worm.exe xmas.exe: %.exe: $(demodir)/%.c

--- a/win32/pdcwin.h
+++ b/win32/pdcwin.h
@@ -19,7 +19,7 @@
 #endif
 #if (defined(__CYGWIN__) || defined(__MINGW32__) || defined(__WATCOMC__) \
      || (defined(_MSC_VER) && _WIN32_WINNT >= _WIN32_WINNT_VISTA))
-   #if !defined(HAVE_INFOEX)
+   #if !defined(HAVE_INFOEX) && !defined(HAVE_NO_INFOEX)
        # define HAVE_INFOEX
    #endif
 #endif


### PR DESCRIPTION
Allow compilation with self-defined INFOEX, needed with old MINGW (and maybe old Watcom, too), by specifying `-DHAVE_NO_INFOEX`.

MinGW actually doesn't define this since years (see https://github.com/wmcbrine/PDCurses/issues/28), which likely changes in some point of time (see https://osdn.net/projects/mingw/ticket/38187).

I'd say it is best to assume it is available on MinGW and WATCOM if not explicit requested otherwise.
I'm not sure about the used names, though...

@Bill-Gray Opinions?