### PR TITLE
compiler warning fix, lib linkage correctness

### DIFF
--- a/demos/testcurs.c
+++ b/demos/testcurs.c
@@ -367,9 +367,6 @@ void introTest(WINDOW *win)
 void scrollTest(WINDOW *win)
 {
     int i, OldY;
-#ifndef PDCURSES
-    int OldX;
-#endif
     werase(win);
     mvwaddstr(win, height - 2, 1, "The window will now scroll slowly");
     box(win, ACS_VLINE, ACS_HLINE);
@@ -384,11 +381,7 @@ void scrollTest(WINDOW *win)
         wrefresh(win);
     };
 
-#ifdef PDCURSES
     OldY = getmaxy(win);
-#else
-    getmaxyx(win, OldY, OldX);
-#endif
     mvwaddstr(win, 6, 1, "The top of the window will scroll");
     wmove(win, 1, 1);
     wsetscrreg(win, 0, 4);

--- a/demos/testcurs.c
+++ b/demos/testcurs.c
@@ -367,6 +367,9 @@ void introTest(WINDOW *win)
 void scrollTest(WINDOW *win)
 {
     int i, OldY;
+#if !defined (PDCURSES) && !defined (NCURSES_VERSION)
+    int OldX;
+#endif
     werase(win);
     mvwaddstr(win, height - 2, 1, "The window will now scroll slowly");
     box(win, ACS_VLINE, ACS_HLINE);
@@ -381,7 +384,11 @@ void scrollTest(WINDOW *win)
         wrefresh(win);
     };
 
+#if defined (PDCURSES) || defined (NCURSES_VERSION)
     OldY = getmaxy(win);
+#else
+    getmaxyx(win, OldY, OldX);
+#endif
     mvwaddstr(win, 6, 1, "The top of the window will scroll");
     wmove(win, 1, 1);
     wsetscrreg(win, 0, 4);

--- a/ncurses/makefile
+++ b/ncurses/makefile
@@ -7,11 +7,12 @@
 
 ifeq ($(WIDE),Y)
  CFLAGS = -Wall -O3 -D_XOPEN_SOURCE_EXTENDED -DHAVE_NCURSESW
+ LIBCURSES = -lncursesw
 else
  CFLAGS = -Wall -O3 -D_XOPEN_SOURCE_EXTENDED
+ LIBCURSES = -lncurses
 endif
 
-LIBCURSES = -lncursesw
 demodir = ../demos
 
 DEMOS    = firework ozdemo newtest rain testcurs worm xmas


### PR DESCRIPTION
1.  Fixes testcurs.c warning:
```
../demos/testcurs.c: In function ‘scrollTest’:
../demos/testcurs.c:371:9: warning: variable ‘OldX’ set but not used [-Wunused-but-set-variable]
     int OldX;
         ^
```

2.  Fixes ncurses makefile, so that it properly links ncurses lib per WIDE=Y/N choice.