### PR TITLE
KEY_RESIZE should be key_code = TRUE in wincon

### DIFF
--- a/wincon/pdckbd.c
+++ b/wincon/pdckbd.c
@@ -744,6 +744,7 @@ int PDC_get_key(void)
                 if (!SP->resized)
                 {
                     SP->resized = TRUE;
+                    SP->key_code = TRUE;
                     return KEY_RESIZE;
                 }
             }


### PR DESCRIPTION
This is a follow-up to 7eb27ea which brought the code from wmcbrine's to
support user resizing of Windows console. Since that time,
https://github.com/wmcbrine/PDCurses/issues/30 was reported and fixed in
wmcbrine's 9cf39fe. This commit mirrors that fix.

While I have your attention.. do you have plans to make a new release anytime soon? I was looking to get resizing working in https://github.com/MitMaro/git-interactive-rebase-tool which relies on https://github.com/ihalila/pdcurses-sys , which makes your code available as a neat Rust crate(package). I feel I should wait for a proper release on your side before asking for the Rust crate to be updated.