### PR TITLE
print actual version information in ozdemo

### DIFF
--- a/demos/ozdemo.c
+++ b/demos/ozdemo.c
@@ -332,8 +332,17 @@ int main(int argc, char **argv)
 
         init_pair(5, COLOR_BLUE, COLOR_WHITE);
         wattrset(win, COLOR_PAIR(5) | A_BLINK);
+#if defined (PDCURSES)
+        mvwprintw(win, height - 2, 2,
+            "PDCurses %d.%d.%d: DOS, OS/2, Windows, X11, SDL",
+            PDC_VER_MAJOR, PDC_VER_MINOR, PDC_VER_CHANGE);
+#elif defined (NCURSES_VERSION)
         mvwaddstr(win, height - 2, 2,
-            " PDCurses 3.4 - DOS, OS/2, Windows, X11, SDL");
+            "         ncurses " NCURSES_VERSION " running ozdemo         ");
+#else
+        mvwaddstr(win, height - 2, 2,
+            "         some curses running ozdemo         ");
+#endif
         wrefresh(win);
 
         /* Draw running messages */


### PR DESCRIPTION
Using PDCurses version numbers (actually providing a minimal test here for `mvwprintw()`) / NCurses version string (concatenated).

This was just a quick hack, therefore it could be possible that other version output should be added (for example the variant used [if this is done (or in any case) we should use the runtime lookup to also test this]) or more curses version strings for different curses implementations.

... and possibly apply this to other demos as well.