### PR TITLE
Removed reference to icon from cmake/version.in.cmake

### DIFF
--- a/cmake/version.in.cmake
+++ b/cmake/version.in.cmake
@@ -45,18 +45,6 @@ BEGIN
         VALUE "Translation", 0x400, 1200, 0x409, 1200
     END
 END
-
-
-/////////////////////////////////////////////////////////////////////////////
-//
-// Icon
-//
-
-// Icon with lowest ID value placed first to ensure application icon
-// remains consistent on all systems.
-1                       ICON                    PRODUCT_ICON
-
-
 #endif    // English (United States) resources
 /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
When running a dll build using MSVC and CMake, I am getting the error RC2135 for the file cmake/version.in. It appears to be related to a missing icon reference.

I believe that after removing the project icon in 4ee573a73c8dfaa10d7934b4239824a9c772e7e6 we need to remove the reference to it in the resource file as well. This patch fixes the issue for me.