### PR TITLE
correct OW cross-compilation CMake scripts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -174,11 +174,11 @@ install:
   - if "%TOOLCHAIN%"=="Watcom20" ( appveyor DownloadFile "%OPEN_WATCOM_URL%" -FileName "%OPEN_WATCOM_NAME%" )
   - if "%TOOLCHAIN%"=="Watcom20" ( 7z x -y "%OPEN_WATCOM_NAME%" -o"%WATCOM%" > nul )
     # todo - check the md5 here...
-  - if "%TOOLCHAIN%"=="Watcom20" ( set "PATH=%WATCOM%\BINNT64;%WATCOM%\BINNT;%PATH%" )
+  - if "%TOOLCHAIN%"=="Watcom20" ( set "PATH=%WATCOM%\BINNT64;%WATCOM%\BINW;%PATH%" )
 
     # DOS BAT file
   - if "%TARGET%"=="dos" ( set "EDPATH=%WATCOM%\EDDAT" )
-  - if "%TARGET%"=="dos" ( set "INCLUDE=%WATCOM%\H;%WATCOM%\H\NT" )
+  - if "%TARGET%"=="dos" ( set "INCLUDE=%WATCOM%\H" )
 
     # OS/2 CMD file
   - if "%TARGET%"=="os2" ( set "BEGINLIBPATH=%WATCOM%\BINP\DLL" )

--- a/cmake/watcom_open_dos16_toolchain.cmake
+++ b/cmake/watcom_open_dos16_toolchain.cmake
@@ -1,12 +1,15 @@
-# This module is shared by multiple languages; use include blocker.
-if(__WINDOWS_OPENWATCOM)
-  return()
-endif()
-set(__WINDOWS_OPENWATCOM 1)
+include_guard()
 
-set(CMAKE_LIBRARY_PATH_FLAG "libpath ")
-set(CMAKE_LINK_LIBRARY_FLAG "library ")
-set(CMAKE_LINK_LIBRARY_FILE_FLAG "library ")
+set(DOS 1)
+
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+
+set(CMAKE_SYSTEM_NAME "Generic")
+set(CMAKE_SYSTEM_PROCESSOR "I86")
+
+set(CMAKE_C_COMPILER "wcl")
+set(CMAKE_CXX_COMPILER "wcl")
+set(CMAKE_ASM_COMPILER "wasm")
 
 if(CMAKE_VERBOSE_MAKEFILE)
   set(CMAKE_WCL_QUIET)
@@ -18,40 +21,57 @@ else()
   set(CMAKE_LIB_QUIET "-q")
 endif()
 
-string(APPEND CMAKE_EXE_LINKER_FLAGS_INIT " ")
+foreach(lang C CXX ASM)
+  set(CMAKE_EXECUTABLE_SUFFIX_${lang} ".exe")
+  set(CMAKE_${lang}_LINK_LIBRARY_SUFFIX ".lib")
+  set(CMAKE_STATIC_LIBRARY_PREFIX_${lang} "")
+  set(CMAKE_STATIC_LIBRARY_SUFFIX_${lang} ".lib")
+  set(CMAKE_SHARED_LIBRARY_PREFIX_${lang} "")
+  set(CMAKE_SHARED_LIBRARY_SUFFIX_${lang} ".dll")
+  set(CMAKE_IMPORT_LIBRARY_PREFIX_${lang} "")
+  set(CMAKE_IMPORT_LIBRARY_SUFFIX_${lang} ".lib")
+endforeach()
+
+set(CMAKE_DL_LIBS "")
+set(CMAKE_FIND_LIBRARY_PREFIXES "")
+set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
+
+set(CMAKE_LIBRARY_PATH_FLAG "libpath ")
+set(CMAKE_LINK_LIBRARY_FLAG "library ")
+set(CMAKE_LINK_LIBRARY_FILE_FLAG "library ")
 
 set(CMAKE_C_COMPILE_OPTIONS_DLL "")
 set(CMAKE_SHARED_LIBRARY_C_FLAGS "")
 
-message(STATUS "Configured for 16-bit DOS")
-set(WATCOM_DOS16 TRUE)
-set(WATCOM_DOS32 FALSE)
-set(CMAKE_C_COMPILER "wcc")
-set(SYSTEM_NAME dos)
+foreach(type EXE SHARED MODULE)
+  set(CMAKE_${type}_LINKER_FLAGS_INIT " system dos opt map")
+  set(CMAKE_${type}_LINKER_FLAGS_DEBUG_INIT " debug all")
+  set(CMAKE_${type}_LINKER_FLAGS_RELWITHDEBINFO_INIT " debug all")
+endforeach()
 
-set(CMAKE_ASM_COMPILER "wasm")
-
-set(CMAKE_BUILD_TYPE_INIT Debug)
-
-string(APPEND CMAKE_C_FLAGS_INIT " -bt=dos")
+set(CMAKE_C_FLAGS_INIT " -w3 -bt=dos")
+set(CMAKE_C_FLAGS_DEBUG_INIT " -d2")
+set(CMAKE_C_FLAGS_MINSIZEREL_INIT " -s -os -d0 -dNDEBUG")
+set(CMAKE_C_FLAGS_RELEASE_INIT " -s -ot -d0 -dNDEBUG")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT " -s -ot -d1 -dNDEBUG")
 
 foreach(type CREATE_SHARED_LIBRARY CREATE_SHARED_MODULE LINK_EXECUTABLE)
   set(CMAKE_C_${type}_USE_WATCOM_QUOTE 1)
 endforeach()
 
 set(CMAKE_C_CREATE_IMPORT_LIBRARY
-  "wlib -q -n -b <TARGET_IMPLIB> +<TARGET_QUOTED>")
+  "wlib ${CMAKE_LIB_QUIET} -c -n -b <TARGET_IMPLIB> +<TARGET_QUOTED>")
 
 set(CMAKE_C_LINK_EXECUTABLE
-  "wlink ${CMAKE_WLINK_QUIET} system dos name <TARGET> <LINK_FLAGS> file {<OBJECTS>} <LINK_LIBRARIES>")
+  "wlink ${CMAKE_WLINK_QUIET} name <TARGET> <LINK_FLAGS> file {<OBJECTS>} <LINK_LIBRARIES>")
 
 # compile a C file into an object file
 set(CMAKE_C_COMPILE_OBJECT
-    "<CMAKE_C_COMPILER> ${CMAKE_WCL_QUIET} -d+ <DEFINES> <INCLUDES> <FLAGS> -fo=\"<OBJECT>\" \"<SOURCE>\"")
+    "<CMAKE_C_COMPILER> ${CMAKE_WCL_QUIET} -d+ <DEFINES> <INCLUDES> <FLAGS> -fo=\"<OBJECT>\" -c -cc \"<SOURCE>\"")
 
 # preprocess a C source file
 set(CMAKE_C_CREATE_PREPROCESSED_SOURCE
-    "<CMAKE_C_COMPILER> ${CMAKE_WCL_QUIET} -d+ <DEFINES> <INCLUDES> <FLAGS> -fo=\"<PREPROCESSED_SOURCE>\" -pl \"<SOURCE>\"")
+    "<CMAKE_C_COMPILER> ${CMAKE_WCL_QUIET} -d+ <DEFINES> <INCLUDES> <FLAGS> -fo=\"<PREPROCESSED_SOURCE>\" -pl -cc \"<SOURCE>\"")
 
 string(REPLACE " option implib=<TARGET_IMPLIB>" ""
   CMAKE_CXX_CREATE_SHARED_MODULE "${CMAKE_CXX_CREATE_SHARED_LIBRARY}")
@@ -65,32 +85,6 @@ set(CMAKE_C_CREATE_SHARED_MODULE ${CMAKE_CXX_CREATE_SHARED_MODULE})
 # create a C static library
 set(CMAKE_C_CREATE_STATIC_LIBRARY "wlib ${CMAKE_LIB_QUIET} -c -n -b <TARGET_QUOTED> <LINK_FLAGS> <OBJECTS> ")
 
-if(NOT _CMAKE_WATCOM_VERSION)
-  set(_CMAKE_WATCOM_VERSION 1)
-  if(CMAKE_C_COMPILER_VERSION)
-    set(_compiler_version ${CMAKE_C_COMPILER_VERSION})
-    set(_compiler_id ${CMAKE_C_COMPILER_ID})
-  endif()
-  set(WATCOM16)
-  set(WATCOM17)
-  set(WATCOM18)
-  set(WATCOM19)
-  set(WATCOM20)
-  if("${_compiler_id}" STREQUAL "OpenWatcom")
-    if("${_compiler_version}" VERSION_LESS 1.7)
-      set(WATCOM16 1)
-    endif()
-    if("${_compiler_version}" VERSION_EQUAL 1.7)
-      set(WATCOM17 1)
-    endif()
-    if("${_compiler_version}" VERSION_EQUAL 1.8)
-      set(WATCOM18 1)
-    endif()
-    if("${_compiler_version}" VERSION_EQUAL 1.9)
-      set(WATCOM19 1)
-    endif()
-    if("${_compiler_version}" VERSION_EQUAL 2.0)
-      set(WATCOM20 1)
-    endif()
-  endif()
-endif()
+message(STATUS "Configured for 16-bit DOS")
+set(WATCOM_DOS16 TRUE)
+set(WATCOM_DOS32 FALSE)

--- a/cmake/watcom_open_dos32_toolchain.cmake
+++ b/cmake/watcom_open_dos32_toolchain.cmake
@@ -1,12 +1,12 @@
-# This module is shared by multiple languages; use include blocker.
-if(__WINDOWS_OPENWATCOM)
-  return()
-endif()
-set(__WINDOWS_OPENWATCOM 1)
+include_guard()
 
-set(CMAKE_LIBRARY_PATH_FLAG "libpath ")
-set(CMAKE_LINK_LIBRARY_FLAG "library ")
-set(CMAKE_LINK_LIBRARY_FILE_FLAG "library ")
+set(DOS 1)
+
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+
+set(CMAKE_SYSTEM_NAME "Generic")
+
+set(CMAKE_ASM_COMPILER "wasm")
 
 if(CMAKE_VERBOSE_MAKEFILE)
   set(CMAKE_WCL_QUIET)
@@ -18,47 +18,57 @@ else()
   set(CMAKE_LIB_QUIET "-q")
 endif()
 
-string(APPEND CMAKE_EXE_LINKER_FLAGS_INIT " ")
+foreach(lang C CXX ASM)
+  set(CMAKE_EXECUTABLE_SUFFIX_${lang} ".exe")
+  set(CMAKE_${lang}_LINK_LIBRARY_SUFFIX ".lib")
+  set(CMAKE_STATIC_LIBRARY_PREFIX_${lang} "")
+  set(CMAKE_STATIC_LIBRARY_SUFFIX_${lang} ".lib")
+  set(CMAKE_SHARED_LIBRARY_PREFIX_${lang} "")
+  set(CMAKE_SHARED_LIBRARY_SUFFIX_${lang} ".dll")
+  set(CMAKE_IMPORT_LIBRARY_PREFIX_${lang} "")
+  set(CMAKE_IMPORT_LIBRARY_SUFFIX_${lang} ".lib")
+endforeach()
+
+set(CMAKE_DL_LIBS "")
+set(CMAKE_FIND_LIBRARY_PREFIXES "")
+set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
+
+set(CMAKE_LIBRARY_PATH_FLAG "libpath ")
+set(CMAKE_LINK_LIBRARY_FLAG "library ")
+set(CMAKE_LINK_LIBRARY_FILE_FLAG "library ")
 
 set(CMAKE_C_COMPILE_OPTIONS_DLL "")
 set(CMAKE_SHARED_LIBRARY_C_FLAGS "")
 
-message(STATUS "Configured for 32-bit DOS")
-set(WATCOM_DOS16 FALSE)
-set(WATCOM_DOS32 TRUE)
-set(CMAKE_C_COMPILER "wcc386")
-set(SYSTEM_NAME dos4g)
+foreach(type EXE SHARED MODULE)
+  set(CMAKE_${type}_LINKER_FLAGS_INIT " system dos4g opt map")
+  set(CMAKE_${type}_LINKER_FLAGS_DEBUG_INIT " debug all")
+  set(CMAKE_${type}_LINKER_FLAGS_RELWITHDEBINFO_INIT " debug all")
+endforeach()
 
-# detect folder, add lib386 directory
-execute_process(
-    COMMAND where ${CMAKE_C_COMPILER}
-    OUTPUT_VARIABLE COMPILER_PATH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-set(CMAKE_ASM_COMPILER "wasm")
-
-set(CMAKE_BUILD_TYPE_INIT Debug)
-
-string(APPEND CMAKE_C_FLAGS_INIT " -bt=dos")
+set(CMAKE_C_FLAGS_INIT " -w3 -bt=dos")
+set(CMAKE_C_FLAGS_DEBUG_INIT " -d2")
+set(CMAKE_C_FLAGS_MINSIZEREL_INIT " -s -os -d0 -dNDEBUG")
+set(CMAKE_C_FLAGS_RELEASE_INIT " -s -ot -d0 -dNDEBUG")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT " -s -ot -d1 -dNDEBUG")
 
 foreach(type CREATE_SHARED_LIBRARY CREATE_SHARED_MODULE LINK_EXECUTABLE)
   set(CMAKE_C_${type}_USE_WATCOM_QUOTE 1)
 endforeach()
 
 set(CMAKE_C_CREATE_IMPORT_LIBRARY
-  "wlib -q -n -b <TARGET_IMPLIB> +<TARGET_QUOTED>")
+  "wlib ${CMAKE_LIB_QUIET} -c -n -b <TARGET_IMPLIB> +<TARGET_QUOTED>")
 
 set(CMAKE_C_LINK_EXECUTABLE
-  "wlink ${CMAKE_WLINK_QUIET} system dos4g name <TARGET> <LINK_FLAGS> file {<OBJECTS>} <LINK_LIBRARIES>")
+  "wlink ${CMAKE_WLINK_QUIET} name <TARGET> <LINK_FLAGS> file {<OBJECTS>} <LINK_LIBRARIES>")
 
 # compile a C file into an object file
 set(CMAKE_C_COMPILE_OBJECT
-    "<CMAKE_C_COMPILER> ${CMAKE_WCL_QUIET} -d+ <DEFINES> <INCLUDES> <FLAGS> -fo=\"<OBJECT>\" \"<SOURCE>\"")
+    "<CMAKE_C_COMPILER> ${CMAKE_WCL_QUIET} -d+ <DEFINES> <INCLUDES> <FLAGS> -fo=\"<OBJECT>\" -c -cc \"<SOURCE>\"")
 
 # preprocess a C source file
 set(CMAKE_C_CREATE_PREPROCESSED_SOURCE
-    "<CMAKE_C_COMPILER> ${CMAKE_WCL_QUIET} -d+ <DEFINES> <INCLUDES> <FLAGS> -fo=\"<PREPROCESSED_SOURCE>\" -pl \"<SOURCE>\"")
+    "<CMAKE_C_COMPILER> ${CMAKE_WCL_QUIET} -d+ <DEFINES> <INCLUDES> <FLAGS> -fo=\"<PREPROCESSED_SOURCE>\" -pl -cc \"<SOURCE>\"")
 
 string(REPLACE " option implib=<TARGET_IMPLIB>" ""
   CMAKE_CXX_CREATE_SHARED_MODULE "${CMAKE_CXX_CREATE_SHARED_LIBRARY}")
@@ -72,32 +82,6 @@ set(CMAKE_C_CREATE_SHARED_MODULE ${CMAKE_CXX_CREATE_SHARED_MODULE})
 # create a C static library
 set(CMAKE_C_CREATE_STATIC_LIBRARY "wlib ${CMAKE_LIB_QUIET} -c -n -b <TARGET_QUOTED> <LINK_FLAGS> <OBJECTS> ")
 
-if(NOT _CMAKE_WATCOM_VERSION)
-  set(_CMAKE_WATCOM_VERSION 1)
-  if(CMAKE_C_COMPILER_VERSION)
-    set(_compiler_version ${CMAKE_C_COMPILER_VERSION})
-    set(_compiler_id ${CMAKE_C_COMPILER_ID})
-  endif()
-  set(WATCOM16)
-  set(WATCOM17)
-  set(WATCOM18)
-  set(WATCOM19)
-  set(WATCOM20)
-  if("${_compiler_id}" STREQUAL "OpenWatcom")
-    if("${_compiler_version}" VERSION_LESS 1.7)
-      set(WATCOM16 1)
-    endif()
-    if("${_compiler_version}" VERSION_EQUAL 1.7)
-      set(WATCOM17 1)
-    endif()
-    if("${_compiler_version}" VERSION_EQUAL 1.8)
-      set(WATCOM18 1)
-    endif()
-    if("${_compiler_version}" VERSION_EQUAL 1.9)
-      set(WATCOM19 1)
-    endif()
-    if("${_compiler_version}" VERSION_EQUAL 2.0)
-      set(WATCOM20 1)
-    endif()
-  endif()
-endif()
+message(STATUS "Configured for 32-bit DOS")
+set(WATCOM_DOS16 FALSE)
+set(WATCOM_DOS32 TRUE)

--- a/cmake/watcom_open_os2v2_toolchain.cmake
+++ b/cmake/watcom_open_os2v2_toolchain.cmake
@@ -1,12 +1,12 @@
-# This module is shared by multiple languages; use include blocker.
-if(__WINDOWS_OPENWATCOM)
-  return()
-endif()
-set(__WINDOWS_OPENWATCOM 1)
+include_guard()
 
-set(CMAKE_LIBRARY_PATH_FLAG "libpath ")
-set(CMAKE_LINK_LIBRARY_FLAG "library ")
-set(CMAKE_LINK_LIBRARY_FILE_FLAG "library ")
+set(OS2 1)
+
+set(CMAKE_SYSTEM_NAME "Generic")
+
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+
+set(CMAKE_ASM_COMPILER "wasm")
 
 if(CMAKE_VERBOSE_MAKEFILE)
   set(CMAKE_WCL_QUIET)
@@ -18,46 +18,57 @@ else()
   set(CMAKE_LIB_QUIET "-q")
 endif()
 
-string(APPEND CMAKE_EXE_LINKER_FLAGS_INIT " ")
+foreach(lang C CXX ASM)
+  set(CMAKE_EXECUTABLE_SUFFIX_${lang} ".exe")
+  set(CMAKE_${lang}_LINK_LIBRARY_SUFFIX ".lib")
+  set(CMAKE_STATIC_LIBRARY_PREFIX_${lang} "")
+  set(CMAKE_STATIC_LIBRARY_SUFFIX_${lang} ".lib")
+  set(CMAKE_SHARED_LIBRARY_PREFIX_${lang} "")
+  set(CMAKE_SHARED_LIBRARY_SUFFIX_${lang} ".dll")
+  set(CMAKE_IMPORT_LIBRARY_PREFIX_${lang} "")
+  set(CMAKE_IMPORT_LIBRARY_SUFFIX_${lang} ".lib")
+endforeach()
+
+set(CMAKE_DL_LIBS "")
+set(CMAKE_FIND_LIBRARY_PREFIXES "")
+set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
+
+set(CMAKE_LIBRARY_PATH_FLAG "libpath ")
+set(CMAKE_LINK_LIBRARY_FLAG "library ")
+set(CMAKE_LINK_LIBRARY_FILE_FLAG "library ")
 
 set(CMAKE_C_COMPILE_OPTIONS_DLL "")
 set(CMAKE_SHARED_LIBRARY_C_FLAGS "")
 
-message(STATUS "Configured for OS/2 v2")
-set(WATCOM_OS2V2 TRUE)
-set(CMAKE_C_COMPILER "wcc386")
-set(SYSTEM_NAME os2v2)
+foreach(type EXE SHARED MODULE)
+  set(CMAKE_${type}_LINKER_FLAGS_INIT " system os2v2 opt map")
+  set(CMAKE_${type}_LINKER_FLAGS_DEBUG_INIT " debug all")
+  set(CMAKE_${type}_LINKER_FLAGS_RELWITHDEBINFO_INIT " debug all")
+endforeach()
 
-# detect folder, add lib386 directory
-execute_process(
-    COMMAND where ${CMAKE_C_COMPILER}
-    OUTPUT_VARIABLE COMPILER_PATH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-set(CMAKE_ASM_COMPILER "wasm")
-
-set(CMAKE_BUILD_TYPE_INIT Debug)
-
-string(APPEND CMAKE_C_FLAGS_INIT " -bt=os2")
+set(CMAKE_C_FLAGS_INIT " -w3 -bt=os2")
+set(CMAKE_C_FLAGS_DEBUG_INIT " -d2")
+set(CMAKE_C_FLAGS_MINSIZEREL_INIT " -s -os -d0 -dNDEBUG")
+set(CMAKE_C_FLAGS_RELEASE_INIT " -s -ot -d0 -dNDEBUG")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT " -s -ot -d1 -dNDEBUG")
 
 foreach(type CREATE_SHARED_LIBRARY CREATE_SHARED_MODULE LINK_EXECUTABLE)
   set(CMAKE_C_${type}_USE_WATCOM_QUOTE 1)
 endforeach()
 
 set(CMAKE_C_CREATE_IMPORT_LIBRARY
-  "wlib -q -n -b <TARGET_IMPLIB> +<TARGET_QUOTED>")
+  "wlib ${CMAKE_LIB_QUIET} -c -n -b <TARGET_IMPLIB> +<TARGET_QUOTED>")
 
 set(CMAKE_C_LINK_EXECUTABLE
-  "wlink ${CMAKE_WLINK_QUIET} system os2v2 name <TARGET> <LINK_FLAGS> file {<OBJECTS>} <LINK_LIBRARIES>")
+  "wlink ${CMAKE_WLINK_QUIET} name <TARGET> <LINK_FLAGS> file {<OBJECTS>} <LINK_LIBRARIES>")
 
 # compile a C file into an object file
 set(CMAKE_C_COMPILE_OBJECT
-    "<CMAKE_C_COMPILER> ${CMAKE_WCL_QUIET} -d+ <DEFINES> <INCLUDES> <FLAGS> -fo=\"<OBJECT>\" \"<SOURCE>\"")
+    "<CMAKE_C_COMPILER> ${CMAKE_WCL_QUIET} -d+ <DEFINES> <INCLUDES> <FLAGS> -fo=\"<OBJECT>\" -c -cc \"<SOURCE>\"")
 
 # preprocess a C source file
 set(CMAKE_C_CREATE_PREPROCESSED_SOURCE
-    "<CMAKE_C_COMPILER> ${CMAKE_WCL_QUIET} -d+ <DEFINES> <INCLUDES> <FLAGS> -fo=\"<PREPROCESSED_SOURCE>\" -pl \"<SOURCE>\"")
+    "<CMAKE_C_COMPILER> ${CMAKE_WCL_QUIET} -d+ <DEFINES> <INCLUDES> <FLAGS> -fo=\"<PREPROCESSED_SOURCE>\" -pl -cc \"<SOURCE>\"")
 
 string(REPLACE " option implib=<TARGET_IMPLIB>" ""
   CMAKE_CXX_CREATE_SHARED_MODULE "${CMAKE_CXX_CREATE_SHARED_LIBRARY}")
@@ -71,32 +82,5 @@ set(CMAKE_C_CREATE_SHARED_MODULE ${CMAKE_CXX_CREATE_SHARED_MODULE})
 # create a C static library
 set(CMAKE_C_CREATE_STATIC_LIBRARY "wlib ${CMAKE_LIB_QUIET} -c -n -b <TARGET_QUOTED> <LINK_FLAGS> <OBJECTS> ")
 
-if(NOT _CMAKE_WATCOM_VERSION)
-  set(_CMAKE_WATCOM_VERSION 1)
-  if(CMAKE_C_COMPILER_VERSION)
-    set(_compiler_version ${CMAKE_C_COMPILER_VERSION})
-    set(_compiler_id ${CMAKE_C_COMPILER_ID})
-  endif()
-  set(WATCOM16)
-  set(WATCOM17)
-  set(WATCOM18)
-  set(WATCOM19)
-  set(WATCOM20)
-  if("${_compiler_id}" STREQUAL "OpenWatcom")
-    if("${_compiler_version}" VERSION_LESS 1.7)
-      set(WATCOM16 1)
-    endif()
-    if("${_compiler_version}" VERSION_EQUAL 1.7)
-      set(WATCOM17 1)
-    endif()
-    if("${_compiler_version}" VERSION_EQUAL 1.8)
-      set(WATCOM18 1)
-    endif()
-    if("${_compiler_version}" VERSION_EQUAL 1.9)
-      set(WATCOM19 1)
-    endif()
-    if("${_compiler_version}" VERSION_EQUAL 2.0)
-      set(WATCOM20 1)
-    endif()
-  endif()
-endif()
+message(STATUS "Configured for OS/2 v2")
+set(WATCOM_OS2V2 TRUE)


### PR DESCRIPTION
overwrite CMake default values, they are only valid for Windows, not for cross-compilation
correct compiler driver name for 16-bit