### PR TITLE
Reorganize .travis.yml file and add DOSVGA wide version build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,31 @@
 language: c
 
+_job_includes:
+  - &ow19_os2
+    os: linux
+    compiler: ow19
+    arch: os2
+  - &ow19_dos
+    os: linux
+    compiler: ow19
+    arch: dos
+  - &ow19_dos32
+    os: linux
+    compiler: ow19
+    arch: dos32
+  - &ow20_os2
+    os: linux
+    compiler: ow20
+    arch: os2
+  - &ow20_dos
+    os: linux
+    compiler: ow20
+    arch: dos
+  - &ow20_dos32
+    os: linux
+    compiler: ow20
+    arch: dos32
+
 os: 
   - linux
   - osx
@@ -13,249 +39,199 @@ arch:
 
 env:
   jobs:
-    - BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_WIDE=OFF -DPDC_UTF8=OFF -DPDCDEBUG=ON"
-    - BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_WIDE=OFF -DPDC_UTF8=ON -DPDCDEBUG=ON"
-    - BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_WIDE=ON -DPDC_UTF8=OFF -DPDCDEBUG=ON"
-  
-    - BUILD_TYPE=Release CMAKE_ARGS="-DPDC_WIDE=OFF -DPDC_UTF8=OFF"
-    - BUILD_TYPE=Release CMAKE_ARGS="-DPDC_WIDE=OFF -DPDC_UTF8=ON"
-    - BUILD_TYPE=Release CMAKE_ARGS="-DPDC_WIDE=ON -DPDC_UTF8=OFF"
+    - BUILD_TYPE=Debug CMAKE_ARGS=""
+    - BUILD_TYPE=Release CMAKE_ARGS=""
+    - BUILD_TYPE=MinSizeRel CMAKE_ARGS=""
 
-    - BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_WIDE=OFF -DPDC_UTF8=OFF"
-    - BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_WIDE=OFF -DPDC_UTF8=ON"
-    - BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_WIDE=ON -DPDC_UTF8=OFF"
+    - BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_UTF8=ON"
+    - BUILD_TYPE=Release CMAKE_ARGS="-DPDC_UTF8=ON"
+    - BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_UTF8=ON"
+
+    - BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_WIDE=ON"
+    - BUILD_TYPE=Release CMAKE_ARGS="-DPDC_WIDE=ON"
+    - BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_WIDE=ON"
 
 jobs:
   include:
+    # Open Watcom 1.9
     # OS/2
-    - arch: os2
-      env: >
-        BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_OS2_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_os2v2_toolchain.cmake -DPDCDEBUG=ON"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${WATCOM}/h/os2:${INCLUDE}
-      os: linux
-      compiler: ow19
-    - arch: os2
-      env: >
-        BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_OS2_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_os2v2_toolchain.cmake -DPDCDEBUG=ON"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${WATCOM}/h/os2:${INCLUDE}
-      os: linux
-      compiler: ow20
-    - arch: os2
-      env: >
-        BUILD_TYPE=Release CMAKE_ARGS="-DPDC_OS2_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_os2v2_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${WATCOM}/h/os2:${INCLUDE}
-      os: linux
-      compiler: ow19
-    - arch: os2
-      env: >
-        BUILD_TYPE=Release CMAKE_ARGS="-DPDC_OS2_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_os2v2_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${WATCOM}/h/os2:${INCLUDE}
-      os: linux
-      compiler: ow20
-    - arch: os2
-      env: >
-        BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_OS2_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_os2v2_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${WATCOM}/h/os2:${INCLUDE}
-      os: linux
-      compiler: ow19
-    - arch: os2
-      env: >
-        BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_OS2_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_os2v2_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${WATCOM}/h/os2:${INCLUDE}
-      os: linux
-      compiler: ow20
+    - <<: *ow19_os2
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_OS2_BUILD=ON" TRAVIS_ARCH=os2
+    - <<: *ow19_os2
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_OS2_BUILD=ON" TRAVIS_ARCH=os2
+    - <<: *ow19_os2
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_OS2_BUILD=ON" TRAVIS_ARCH=os2
     # DOS 16-bit
-    - arch: dos
-      env: >
-        BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOS_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos16_toolchain.cmake -DPDCDEBUG=ON"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow19
-    - arch: dos
-      env: >
-        BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOS_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos16_toolchain.cmake -DPDCDEBUG=ON"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow20
-    - arch: dos
-      env: >
-        BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOS_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos16_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow19
-    - arch: dos
-      env: >
-        BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOS_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos16_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow20
-    - arch: dos
-      env: >
-        BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOS_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos16_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow19
-    - arch: dos
-      env: >
-        BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOS_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos16_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow20
+    - <<: *ow19_dos
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOS_BUILD=ON" TRAVIS_ARCH=dos
+    - <<: *ow19_dos
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOS_BUILD=ON" TRAVIS_ARCH=dos
+    - <<: *ow19_dos
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOS_BUILD=ON" TRAVIS_ARCH=dos
     # DOS 32-bit
-    - arch: dos32
-      env: >
-        BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOS_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos32_toolchain.cmake -DPDCDEBUG=ON"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow19
-    - arch: dos32
-      env: >
-        BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOS_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos32_toolchain.cmake -DPDCDEBUG=ON"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow20
-    - arch: dos32
-      env: >
-        BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOS_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos32_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow19
-    - arch: dos32
-      env: >
-        BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOS_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos32_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow20
-    - arch: dos32
-      env: >
-        BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOS_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos32_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow19
-    - arch: dos32
-      env: >
-        BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOS_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos32_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow20
+    - <<: *ow19_dos32
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOS_BUILD=ON" TRAVIS_ARCH=dos32
+    - <<: *ow19_dos32
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOS_BUILD=ON" TRAVIS_ARCH=dos32
+    - <<: *ow19_dos32
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOS_BUILD=ON" TRAVIS_ARCH=dos32
+    # DOSVGA project
     # DOS 16-bit
-    - arch: dos
-      env: >
-        BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos16_toolchain.cmake -DPDCDEBUG=ON"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow19
-    - arch: dos
-      env: >
-        BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos16_toolchain.cmake -DPDCDEBUG=ON"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow20
-    - arch: dos
-      env: >
-        BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos16_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow19
-    - arch: dos
-      env: >
-        BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos16_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow20
-    - arch: dos
-      env: >
-        BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos16_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow19
-    - arch: dos
-      env: >
-        BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos16_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow20
+    - <<: *ow19_dos
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON" TRAVIS_ARCH=dos
+    - <<: *ow19_dos
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON" TRAVIS_ARCH=dos
+    - <<: *ow19_dos
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON" TRAVIS_ARCH=dos
     # DOS 32-bit
-    - arch: dos32
-      env: >
-        BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos32_toolchain.cmake -DPDCDEBUG=ON"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow19
-    - arch: dos32
-      env: >
-        BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos32_toolchain.cmake -DPDCDEBUG=ON"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow20
-    - arch: dos32
-      env: >
-        BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos32_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow19
-    - arch: dos32
-      env: >
-        BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos32_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow20
-    - arch: dos32
-      env: >
-        BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos32_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow19
-    - arch: dos32
-      env: >
-        BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos32_toolchain.cmake"
-        WATCOM=${HOME}/watcom INCLUDE=${WATCOM}/h:${INCLUDE}
-      os: linux
-      compiler: ow20
+    - <<: *ow19_dos32
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON" TRAVIS_ARCH=dos32
+    - <<: *ow19_dos32
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON" TRAVIS_ARCH=dos32
+    - <<: *ow19_dos32
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON" TRAVIS_ARCH=dos32
+    # DOSVGA project WIDE version
+    # DOS 16-bit
+    - <<: *ow19_dos
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DPDC_WIDE=ON" TRAVIS_ARCH=dos
+    - <<: *ow19_dos
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DPDC_WIDE=ON" TRAVIS_ARCH=dos
+    - <<: *ow19_dos
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DPDC_WIDE=ON" TRAVIS_ARCH=dos
+    # DOS 32-bit
+    - <<: *ow19_dos32
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DPDC_WIDE=ON" TRAVIS_ARCH=dos32
+    - <<: *ow19_dos32
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DPDC_WIDE=ON" TRAVIS_ARCH=dos32
+    - <<: *ow19_dos32
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DPDC_WIDE=ON" TRAVIS_ARCH=dos32
+    # Open Watcom 2.0
+    # OS/2
+    - <<: *ow20_os2
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_OS2_BUILD=ON" TRAVIS_ARCH=os2
+    - <<: *ow20_os2
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_OS2_BUILD=ON" TRAVIS_ARCH=os2
+    - <<: *ow20_os2
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_OS2_BUILD=ON" TRAVIS_ARCH=os2
+    # DOS 16-bit
+    - <<: *ow20_dos
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOS_BUILD=ON" TRAVIS_ARCH=dos
+    - <<: *ow20_dos
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOS_BUILD=ON" TRAVIS_ARCH=dos
+    - <<: *ow20_dos
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOS_BUILD=ON" TRAVIS_ARCH=dos
+    # DOS 32-bit
+    - <<: *ow20_dos32
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOS_BUILD=ON" TRAVIS_ARCH=dos32
+    - <<: *ow20_dos32
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOS_BUILD=ON" TRAVIS_ARCH=dos32
+    - <<: *ow20_dos32
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOS_BUILD=ON" TRAVIS_ARCH=dos32
+    # DOSVGA project
+    # DOS 16-bit
+    - <<: *ow20_dos
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON" TRAVIS_ARCH=dos
+    - <<: *ow20_dos
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON" TRAVIS_ARCH=dos
+    - <<: *ow20_dos
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON" TRAVIS_ARCH=dos
+    # DOS 32-bit
+    - <<: *ow20_dos32
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON" TRAVIS_ARCH=dos32
+    - <<: *ow20_dos32
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON" TRAVIS_ARCH=dos32
+    - <<: *ow20_dos32
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON" TRAVIS_ARCH=dos32
+    # DOSVGA project WIDE version
+    # DOS 16-bit
+    - <<: *ow20_dos
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DPDC_WIDE=ON" TRAVIS_ARCH=dos
+    - <<: *ow20_dos
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DPDC_WIDE=ON" TRAVIS_ARCH=dos
+    - <<: *ow20_dos
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DPDC_WIDE=ON" TRAVIS_ARCH=dos
+    # DOS 32-bit
+    - <<: *ow20_dos32
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DPDC_WIDE=ON" TRAVIS_ARCH=dos32
+    - <<: *ow20_dos32
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DPDC_WIDE=ON" TRAVIS_ARCH=dos32
+    - <<: *ow20_dos32
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DPDC_WIDE=ON" TRAVIS_ARCH=dos32
 
-before_install:
-  - if [[ "${TRAVIS_COMPILER}" == "ow19" ]]; then export OPEN_WATCOM_NAME=open-watcom-c-linux-1.9; fi
-  - if [[ "${TRAVIS_COMPILER}" == "ow20" ]]; then export OPEN_WATCOM_NAME=open-watcom-2_0-c-linux-x64; fi
-  - if [[ "${TRAVIS_COMPILER}" == "ow19" ]]; 
-      then export OPEN_WATCOM_URL=https://sourceforge.net/projects/openwatcom/files/open-watcom-1.9/${OPEN_WATCOM_NAME}; fi
-  - if [[ "${TRAVIS_COMPILER}" == "ow20" ]]; 
-      then export OPEN_WATCOM_URL=https://github.com/open-watcom/open-watcom-v2/releases/download/Current-build/${OPEN_WATCOM_NAME}; fi
+install:
+  # install required version of CMake
+  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      ARTIFACT_NAME=cmake-3.11.0-Linux-x86_64;
+      ARTIFACT_URL=https://cmake.org/files/v3.11/${ARTIFACT_NAME}.tar.gz;
+      ARTIFACT_MD5=96d67e21f0983ebf0fffc5b106ec338c;
+      travis_retry wget --no-check-certificate -P ${TRAVIS_TMPDIR} ${ARTIFACT_URL};
+      echo "${ARTIFACT_MD5} *${TRAVIS_TMPDIR}/${ARTIFACT_NAME}.tar.gz" > ${TRAVIS_TMPDIR}/cmake_md5.txt;
+      md5sum -c ${TRAVIS_TMPDIR}/cmake_md5.txt;
+      mkdir -p ${TRAVIS_HOME}/cmake;
+      tar -xf ${TRAVIS_TMPDIR}/${ARTIFACT_NAME}.tar.gz -C ${TRAVIS_HOME}/cmake --strip-components=1 --show-transformed-names ${ARTIFACT_NAME};
+      export PATH=${TRAVIS_HOME}/cmake:${TRAVIS_HOME}/cmake/bin:$PATH;
+    fi
+  # install Open Watcom 1.9
+  - if [[ "${TRAVIS_COMPILER}" == "ow19" ]]; then
+      ARTIFACT_NAME=open-watcom-c-linux-1.9;
+      ARTIFACT_URL=https://sourceforge.net/projects/openwatcom/files/open-watcom-1.9/${ARTIFACT_NAME};
+      OPEN_WATCOM_BIN=binl;
+      travis_retry wget --no-check-certificate -P ${TRAVIS_TMPDIR} ${ARTIFACT_URL};
+      export WATCOM=${TRAVIS_HOME}/watcom;
+      mkdir -p ${WATCOM};
+      unzip -q ${TRAVIS_TMPDIR}/${ARTIFACT_NAME} -d ${WATCOM};
+      chmod +x ${WATCOM}/${OPEN_WATCOM_BIN}/*;
+      export PATH=${WATCOM}/binl:${WATCOM}/binw:$PATH;
+    fi
+  # install Open Watcom 2.0
+  - if [[ "${TRAVIS_COMPILER}" == "ow20" ]]; then
+      ARTIFACT_NAME=open-watcom-2_0-c-linux-x64;
+      ARTIFACT_URL=https://github.com/open-watcom/open-watcom-v2/releases/download/Current-build/${ARTIFACT_NAME};
+      OPEN_WATCOM_BIN=binl64;
+      travis_retry wget --no-check-certificate -P ${TRAVIS_TMPDIR} ${ARTIFACT_URL};
+      export WATCOM=${TRAVIS_HOME}/watcom;
+      mkdir -p ${WATCOM};
+      unzip -q ${TRAVIS_TMPDIR}/${ARTIFACT_NAME} -d ${WATCOM};
+      chmod +x ${WATCOM}/${OPEN_WATCOM_BIN}/*;
+      export PATH=${WATCOM}/binl64:${WATCOM}/binw:$PATH;
+    fi
 
-install: 
+  # install ncurses on Linux, not for OpenWatcom toolchain
   - if [[ "${TRAVIS_OS_NAME}" == "linux" && "${TRAVIS_COMPILER}" != "ow19" && "${TRAVIS_COMPILER}" != "ow20" ]]; 
       then sudo apt-get -y install libncurses5-dev libncursesw5-dev libxaw7-dev; fi
-  - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew install ncurses; fi
+  # install ncurses on OSX
+  - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; 
+      then brew install ncurses; fi
 
-  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"; fi
-  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then mkdir ${DEPS_DIR} && cd ${DEPS_DIR} && pwd; fi
-  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then travis_retry wget --no-check-certificate https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.tar.gz; fi
-  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then echo "96d67e21f0983ebf0fffc5b106ec338c *cmake-3.11.0-Linux-x86_64.tar.gz" > cmake_md5.txt; fi
-  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then md5sum -c cmake_md5.txt; fi
-  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then tar -xvf cmake-3.11.0-Linux-x86_64.tar.gz > /dev/null; fi
-  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then mv cmake-3.11.0-Linux-x86_64 cmake-install; fi
-  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then PATH=${DEPS_DIR}/cmake-install:${DEPS_DIR}/cmake-install/bin:$PATH; fi
-
-  - if [[ "${TRAVIS_COMPILER}" == "ow19" || "${TRAVIS_COMPILER}" == "ow20" ]]; then mkdir -p ${WATCOM}; fi
-  - if [[ "${TRAVIS_COMPILER}" == "ow19" || "${TRAVIS_COMPILER}" == "ow20" ]]; then travis_retry wget --no-check-certificate ${OPEN_WATCOM_URL}; fi
-  - if [[ "${TRAVIS_COMPILER}" == "ow19" || "${TRAVIS_COMPILER}" == "ow20" ]]; then unzip ${OPEN_WATCOM_NAME} -d ${WATCOM}; fi
-  - if [[ "${TRAVIS_COMPILER}" == "ow19" ]]; then chmod +x ${WATCOM}/binl/*; fi
-  - if [[ "${TRAVIS_COMPILER}" == "ow20" ]]; then chmod +x ${WATCOM}/binl64/*; fi
-  - if [[ "${TRAVIS_COMPILER}" == "ow19" ]]; then export PATH=${WATCOM}/binl:${WATCOM}/binw:$PATH; fi
-  - if [[ "${TRAVIS_COMPILER}" == "ow20" ]]; then export PATH=${WATCOM}/binl64:${WATCOM}/binw:$PATH; fi
+  # setup Open Watcom for cross-compilation
+  - if [[ "${TRAVIS_ARCH}" == "os2" ]]; then
+      export TOOLCHAIN_FILE="-DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_os2v2_toolchain.cmake";
+      export INCLUDE=${WATCOM}/h:${WATCOM}/h/os2:${INCLUDE};
+    fi
+  - if [[ "${TRAVIS_ARCH}" == "dos" ]]; then
+      export TOOLCHAIN_FILE="-DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos16_toolchain.cmake";
+      export INCLUDE=${WATCOM}/h:${INCLUDE};
+    fi
+  - if [[ "${TRAVIS_ARCH}" == "dos32" ]]; then
+      export TOOLCHAIN_FILE="-DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos32_toolchain.cmake";
+      export INCLUDE=${WATCOM}/h:${INCLUDE};
+    fi
+  - if [[ "${BUILD_TYPE}" == "Debug" ]]; then
+      export CMAKE_DEBUG_ARGS="-DPDCDEBUG=ON";
+    fi
 
 before_script:
   - cd ${TRAVIS_BUILD_DIR}
   - mkdir build && cd build
   - if [[ "${TRAVIS_COMPILER}" == "ow19" || "${TRAVIS_COMPILER}" == "ow20" ]]; then
       cmake -G "Watcom WMake" -DCMAKE_VERBOSE_MAKEFILE=FALSE -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
-          -DPDC_BUILD_SHARED=OFF -DPDC_SDL2_BUILD=OFF -DPDC_SDL2_DEPS_BUILD=OFF
-          -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/build/dist $CMAKE_ARGS
-          .. ;
+        -DPDC_BUILD_SHARED=OFF -DPDC_SDL2_BUILD=OFF -DPDC_SDL2_DEPS_BUILD=OFF ${TOOLCHAIN_FILE}
+        -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/build/dist ${CMAKE_DEBUG_ARGS}
+        ${CMAKE_ARGS} .. ;
     else
       cmake -DCMAKE_VERBOSE_MAKEFILE=FALSE -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
-          -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/build/dist $CMAKE_ARGS
-          .. ;
+        -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/build/dist ${CMAKE_DEBUG_ARGS}
+        ${CMAKE_ARGS} .. ;
     fi
-
 script:
   - cmake --build . --config ${BUILD_TYPE} --target install


### PR DESCRIPTION
reorganize file to be more readable
use travis matrix dimensions environment variables to define all dependent variables to simplify travis jobs definition
setup TRAVIS_ARCH environment variable because Travis doesn't handle it correctly (new feature, not fully implemented)
use YML anchors and aliases to do file more readable
add DOSVGA wide version build