### PR TITLE
ignore multi-monitor setup when compiled for old Win32

### DIFF
--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -2083,6 +2083,10 @@ the window will still be entirely on-screen.
 These functions entered the Win32 API with Windows 2000.  If
 MONITOR_DEFAULTTONEAREST isn't defined,  we shouldn't try to do this.  */
 
+#if WINVER <= 0x0500
+#undef MONITOR_DEFAULTTONEAREST
+#endif
+
 #ifdef MONITOR_DEFAULTTONEAREST
 
 static void clip_or_center_rect_to_monitor( LPRECT prc)


### PR DESCRIPTION
- make wingui work on windows nt4 (and windows 2000) by undefining  MONITOR_DEFAULTTONEAREST when WINVER <= 0x0500 (win2k)