### PR TITLE
travis add WINCON and WINGUI project build for Open Watcom compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ _job_includes:
     os: linux
     compiler: ow19
     arch: dos32
+  - &ow19_win32
+    os: linux
+    compiler: ow19
+    arch: win32
   - &ow20_os2
     os: linux
     compiler: ow20
@@ -25,6 +29,10 @@ _job_includes:
     os: linux
     compiler: ow20
     arch: dos32
+  - &ow20_win32
+    os: linux
+    compiler: ow20
+    arch: win32
 
 os: 
   - linux
@@ -105,6 +113,20 @@ jobs:
       env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DPDC_WIDE=ON" TRAVIS_ARCH=dos32
     - <<: *ow19_dos32
       env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DPDC_WIDE=ON" TRAVIS_ARCH=dos32
+    # WIN32 projects WIDE version
+    - <<: *ow19_win32
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_WIDE=ON" TRAVIS_ARCH=win32
+    - <<: *ow19_win32
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_WIDE=ON" TRAVIS_ARCH=win32
+    - <<: *ow19_win32
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_WIDE=ON" TRAVIS_ARCH=win32
+    # WIN32 projects UTF8 version
+    - <<: *ow19_win32
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_UTF8=ON" TRAVIS_ARCH=win32
+    - <<: *ow19_win32
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_UTF8=ON" TRAVIS_ARCH=win32
+    - <<: *ow19_win32
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_UTF8=ON" TRAVIS_ARCH=win32
     # Open Watcom 2.0
     # OS/2
     - <<: *ow20_os2
@@ -157,6 +179,20 @@ jobs:
       env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DPDC_WIDE=ON" TRAVIS_ARCH=dos32
     - <<: *ow20_dos32
       env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_DOSVGA_BUILD=ON -DPDC_WIDE=ON" TRAVIS_ARCH=dos32
+    # WIN32 projects WIDE version
+    - <<: *ow20_win32
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_WIDE=ON" TRAVIS_ARCH=win32
+    - <<: *ow20_win32
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_WIDE=ON" TRAVIS_ARCH=win32
+    - <<: *ow20_win32
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_WIDE=ON" TRAVIS_ARCH=win32
+    # WIN32 projects UTF8 version
+    - <<: *ow20_win32
+      env: BUILD_TYPE=Debug CMAKE_ARGS="-DPDC_UTF8=ON" TRAVIS_ARCH=win32
+    - <<: *ow20_win32
+      env: BUILD_TYPE=Release CMAKE_ARGS="-DPDC_UTF8=ON" TRAVIS_ARCH=win32
+    - <<: *ow20_win32
+      env: BUILD_TYPE=MinSizeRel CMAKE_ARGS="-DPDC_UTF8=ON" TRAVIS_ARCH=win32
 
 install:
   # install required version of CMake
@@ -216,9 +252,14 @@ install:
       export TOOLCHAIN_FILE="-DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_dos32_toolchain.cmake";
       export INCLUDE=${WATCOM}/h:${INCLUDE};
     fi
+  - if [[ "${TRAVIS_ARCH}" == "win32" ]]; then
+      export TOOLCHAIN_FILE="-DCMAKE_TOOLCHAIN_FILE=${TRAVIS_BUILD_DIR}/cmake/watcom_open_win32_toolchain.cmake";
+      export INCLUDE=${WATCOM}/h:${WATCOM}/h/nt:${INCLUDE};
+    fi
   - if [[ "${BUILD_TYPE}" == "Debug" ]]; then
       export CMAKE_DEBUG_ARGS="-DPDCDEBUG=ON";
     fi
+  - cmake --version
 
 before_script:
   - cd ${TRAVIS_BUILD_DIR}

--- a/cmake/watcom_open_win32_toolchain.cmake
+++ b/cmake/watcom_open_win32_toolchain.cmake
@@ -1,0 +1,12 @@
+include_guard()
+
+set(CMAKE_SYSTEM_NAME "Windows")
+
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+
+set(CMAKE_C_COMPILER "wcl386")
+set(CMAKE_CXX_COMPILER "wcl386")
+set(CMAKE_ASM_COMPILER "wasm")
+
+message(STATUS "Configured for Windows (32-bit)")
+set(WATCOM_WIN32 TRUE)


### PR DESCRIPTION
add CMake configuration file for Windows cross-compilation from Linux to Windows
use existing CMake Windows support file that only minimal definition is necessary
include win32 projects to build by travis