### PR TITLE
cmake: add -static-libgcc on mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ project(pdcurses VERSION "${CURSES_VERSION}" LANGUAGES C)
 if(MSVC)
     set(CMAKE_DEBUG_POSTFIX d)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")  # enable parallel builds
+elseif(MINGW)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static-libgcc")  # avoid libgcc_s_sjlj-1.dll dependency just for __udivdi3
 endif()
 
 message(STATUS "Generator .............. ${CMAKE_GENERATOR}")


### PR DESCRIPTION
In wingui/pdcscrn.c the function milliseconds_since_1970
there is a 64bit division, not native on 32bit,
so mingw picks _udivdi3 from libgcc_s_sjlj-1.dll if dynamic linked.
Avoid it by adding -static-libgcc