### PR TITLE
Watcom review/correct build make files

### DIFF
--- a/common/watcom.mif
+++ b/common/watcom.mif
@@ -1,16 +1,25 @@
 # Common elements for the Watcom makefiles
 
-CFLAGS += -wx -zq -i=$(PDCURSES_SRCDIR)
+CFLAGS += -bt=$(TARGET) -wx -zq -i=$(PDCURSES_SRCDIR)
 
 !ifeq DEBUG Y
 CFLAGS		+= -d2 -DPDCDEBUG
-LDFLAGS		= D W A op q sys $(TARGET)
+LDFLAGS		= D W A op q sys $(LTARGET)
 !else
 CFLAGS		+= -oneatx
-LDFLAGS		= op q sys $(TARGET)
+LDFLAGS		= op q sys $(LTARGET)
+!endif
+
+!ifeq TARGET dos
+CFLAGS += -i="$(%WATCOM)/h"
+!else ifeq TARGET os2
+CFLAGS += -i="$(%WATCOM)/h" -i="$(%WATCOM)/h/os2"
+!else ifeq TARGET nt
+CFLAGS += -i="$(%WATCOM)/h" -i="$(%WATCOM)/h/nt"
 !endif
 
 RM		= del
+
 LIBEXE		= wlib -q -n -b -c -t
 
 srcdir = $(PDCURSES_SRCDIR)/pdcurses
@@ -44,10 +53,10 @@ LINK = wlink
 all:	$(LIBCURSES)
 
 clean
-	-$(RM) *.obj
-	-$(RM) *.lib
-	-$(RM) *.exe
-	-$(RM) *.err
+	@if exist *.obj -$(RM) *.obj
+	@if exist *.lib -$(RM) *.lib
+	@if exist *.exe -$(RM) *.exe
+	@if exist *.err -$(RM) *.err
 
 demos:	$(DEMOS)
 

--- a/dos/Makefile.wcc
+++ b/dos/Makefile.wcc
@@ -17,15 +17,17 @@ PDCURSES_SRCDIR	= ..
 
 osdir		= $(PDCURSES_SRCDIR)/dos
 
+TARGET		= dos
+
 !ifeq MODEL f
 CC		= wcc386
-TARGET		= dos4g
+LTARGET		= dos4g
 !else
 CC		= wcc
-TARGET		= dos
+LTARGET		= dos
 !endif
 
-CFLAGS		= -bt=$(TARGET) -m$(MODEL)
+CFLAGS		= -m$(MODEL)
 
 !include $(PDCURSES_SRCDIR)/common/watcom.mif
 

--- a/dosvga/Makefile.wcc
+++ b/dosvga/Makefile.wcc
@@ -17,15 +17,17 @@ PDCURSES_SRCDIR	= ..
 
 osdir		= $(PDCURSES_SRCDIR)/dosvga
 
+TARGET		= dos
+
 !ifeq MODEL f
 CC		= wcc386
-TARGET		= dos4g
+LTARGET		= dos4g
 !else
 CC		= wcc
-TARGET		= dos
+LTARGET		= dos
 !endif
 
-CFLAGS		= -bt=$(TARGET) -m$(MODEL)
+CFLAGS		= -m$(MODEL)
 
 !ifeq WIDE Y
 CFLAGS		+= -DPDC_WIDE

--- a/os2/Makefile.wcc
+++ b/os2/Makefile.wcc
@@ -15,18 +15,22 @@ PDCURSES_SRCDIR	= ..
 
 osdir		= $(PDCURSES_SRCDIR)\os2
 
-CC		= wcc386
-TARGET		= os2v2
+TARGET		= os2
 
-CFLAGS		= /bt=$(TARGET) /wx /s /zq /i=$(PDCURSES_SRCDIR)
+CC		= wcc386
+LTARGET		= os2v2
+
+CFLAGS		= /mf /bt=$(TARGET) /wx /s /zq /i=$(PDCURSES_SRCDIR)
 
 !ifeq DEBUG Y
 CFLAGS  	+= /d2 /DPDCDEBUG
-LDFLAGS 	= D A op q sys $(TARGET)
+LDFLAGS 	= D A op q sys $(LTARGET)
 !else
 CFLAGS  	+= /oneatx
-LDFLAGS 	= op q sys $(TARGET)
+LDFLAGS 	= op q sys $(LTARGET)
 !endif
+
+CFLAGS  	+= /i="$(%WATCOM)/h" /i="$(%WATCOM)/h/os2"
 
 LIBEXE		= wlib /q /n /b /c /t
 
@@ -37,7 +41,7 @@ $(LIBCURSES) : $(LIBOBJS) $(PDCOBJS)
 	-copy $(LIBCURSES) panel.lib
 
 PLATFORM1	= Watcom C++ OS/2
-PLATFORM2	= Open Watcom 1.6 for OS/2
+PLATFORM2	= Open Watcom for OS/2
 ARCNAME		= pdc$(VER)_wcc_os2
 
 !include $(PDCURSES_SRCDIR)\makedist.mif

--- a/vt/Makefile.wcc
+++ b/vt/Makefile.wcc
@@ -45,43 +45,27 @@ CROSS      = Y
 !endif
 
 osdir      = $(PDCURSES_SRCDIR)/vt
-# Open Watcom README strongly recommends setting WATCOM environment variable...
-!ifeq CROSS Y
-!ifdef %WATCOM
-watcomdir   = $(%WATCOM)
-!else
-watcomdir   = "`which wcc | xargs realpath | xargs dirname`"/..
-!endif
-!endif
+
+TARGET		= dos
 
 !ifneq MODEL f
-CC      = wcc
-TARGET      = dos
+CC      	= wcc
+LTARGET		= dos
 !else
-CC      = wcc386
-TARGET      = dos4g
+CC      	= wcc386
+LTARGET		= dos4g
 !endif
 
-CFLAGS      = -bt=$(TARGET) -zq -wx -m$(MODEL) -i=$(PDCURSES_SRCDIR)
+CFLAGS      = -m$(MODEL) -bt=$(TARGET) -zq -wx -i=$(PDCURSES_SRCDIR)
 CFLAGS      += $(CHTYPE) -DDOS
-# the README also recommends setting INCLUDE; if absent, we need an extra -i=
-!ifndef %INCLUDE
-CFLAGS      += -i=$(watcomdir)/h
-!endif
+CFLAGS      += -i="$(%WATCOM)/h"
 
 !ifeq DEBUG Y
 CFLAGS     += -d2 -DPDCDEBUG
-LDFLAGS    = D W A op q sys $(TARGET)
+LDFLAGS    = D W A op q sys $(LTARGET)
 !else
 CFLAGS     += -oneatx
-LDFLAGS      = op q sys $(TARGET)
-!ifeq CROSS Y
-!ifneq MODEL f
-LDFLAGS      += libp $(watcomdir)/lib286/dos\;$(watcomdir)/lib286
-!else
-LDFLAGS      += libp $(watcomdir)/lib386/dos\;$(watcomdir)/lib386
-!endif
-!endif
+LDFLAGS      = op q sys $(LTARGET)
 !endif
 
 LIBEXE      = wlib -q -n -t
@@ -96,11 +80,11 @@ $(LIBCURSES) : $(LIBOBJS) $(PDCOBJS)
 
 !ifneq MODEL f
 PLATFORM1   = Watcom C++ 16-bit DOS/VT
-PLATFORM2   = Open Watcom 1.6 for 16-bit DOS/VT
+PLATFORM2   = Open Watcom for 16-bit DOS/VT
 ARCNAME      = pdc$(VER)16w
 !else
 PLATFORM1   = Watcom C++ 32-bit DOS/VT
-PLATFORM2   = Open Watcom 1.6 for 32-bit DOS/VT
+PLATFORM2   = Open Watcom for 32-bit DOS/VT
 ARCNAME      = pdc$(VER)32w
 !endif
 

--- a/watcom.mif
+++ b/watcom.mif
@@ -39,10 +39,10 @@ LINK = wlink
 all:	$(LIBCURSES) $(DEMOS)
 
 clean
-	-$(DEL) *.obj
-	-$(DEL) *.lib
-	-$(DEL) *.exe
-	-$(DEL) *.err
+	@if exist *.obj -$(DEL) *.obj
+	@if exist *.lib -$(DEL) *.lib
+	@if exist *.exe -$(DEL) *.exe
+	@if exist *.err -$(DEL) *.err
 
 demos:	$(DEMOS)
 

--- a/wincon/Makefile.wcc
+++ b/wincon/Makefile.wcc
@@ -14,10 +14,12 @@ PDCURSES_SRCDIR	= ..
 
 osdir		= $(PDCURSES_SRCDIR)/wincon
 
-CC		= wcc386
 TARGET		= nt
 
-CFLAGS		= -bt=$(TARGET)
+CC		= wcc386
+LTARGET		= nt
+
+CFLAGS		= -mf
 
 !ifeq WIDE Y
 CFLAGS		+= -DPDC_WIDE

--- a/wingui/Makefile.wcc
+++ b/wingui/Makefile.wcc
@@ -15,17 +15,19 @@ PDCURSES_SRCDIR   = ..
 
 osdir      = $(PDCURSES_SRCDIR)/wingui
 
-CC      = wcc386
-TARGET      = nt_win
+TARGET      = nt
 
-CFLAGS      = -ei -zq -wx -i=$(PDCURSES_SRCDIR)
+CC      = wcc386
+LTARGET     = nt_win
+
+CFLAGS      = -mf -bt=$(TARGET) -ei -zq -wx -i=$(PDCURSES_SRCDIR)
 
 !ifeq DEBUG Y
 CFLAGS      += -hd -od -d2 -dDEBUG -DPDCDEBUG
-LDFLAGS      = DEBUG ALL op q sys $(TARGET)
+LDFLAGS      = DEBUG ALL op q sys $(LTARGET)
 !else
 CFLAGS      += -oneatx
-LDFLAGS      = op q sys $(TARGET)
+LDFLAGS      = op q sys $(LTARGET)
 !endif
 
 !ifeq WIDE Y
@@ -36,6 +38,8 @@ CFLAGS      += -DPDC_WIDE
 CFLAGS      += -DPDC_FORCE_UTF8
 !endif
 
+CFLAGS      += -i"$(%WATCOM)/h" -i"$(%WATCOM)/h/nt"
+
 LIBEXE      = wlib -q -n -t
 
 !include $(PDCURSES_SRCDIR)/watcom.mif
@@ -45,7 +49,7 @@ $(LIBCURSES) : $(LIBOBJS) $(PDCOBJS)
    copy $(LIBCURSES) panel.lib
 
 PLATFORM1   = Watcom C++ WinGUI
-PLATFORM2   = Open Watcom 1.6 for WinGUI
-ARCNAME      = pdc$(VER)_wcc_w32
+PLATFORM2   = Open Watcom for WinGUI
+ARCNAME     = pdc$(VER)_wcc_w32
 
 !include $(PDCURSES_SRCDIR)/makedist.mif


### PR DESCRIPTION
The main discrepancy is that Watcom distinguish between compiler and linker target
by example compiler target is DOS but linker target can be various DOS Extenders
by default compiler target is `-bt=dos` and linker target is DOS4GW extender `sys dos4g`