### PR TITLE
Add VT project build for Open Watcom cross-compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ else()
         
     endif()
 
-    if(UNIX)
+    if(UNIX OR WATCOM)
         add_subdirectory(vt)
     endif()
 


### PR DESCRIPTION
add it only for Windows target for now because it requires TCP/IP header files
for DOS some TCP/IP implementation must be selected