### PR TITLE
correct memory model setup for Open Watcom

### DIFF
--- a/dos/CMakeLists.txt
+++ b/dos/CMakeLists.txt
@@ -16,10 +16,10 @@ if(WATCOM)
 
     string(APPEND CMAKE_C_FLAGS " -wx")  # warning level: to maximum setting
     
-    if(WATCOM_DOS32)
-        string(APPEND CMAKE_C_FLAGS " -mf")  # memory model: options are flat (-mf), large (-ml), memdium (-mm), small (-ms)
-    else()
+    if(WATCOM_DOS16)
         string(APPEND CMAKE_C_FLAGS " -ml")  # memory model: options are large (-ml), memdium (-mm), small (-ms)
+    else()
+        string(APPEND CMAKE_C_FLAGS " -mf")  # memory model: options are flat (-mf), large (-ml), memdium (-mm), small (-ms)
     endif()
 
     string(APPEND CMAKE_C_FLAGS_RELEASE " -oneatx")

--- a/dosvga/CMakeLists.txt
+++ b/dosvga/CMakeLists.txt
@@ -16,10 +16,10 @@ if(WATCOM)
 
     string(APPEND CMAKE_C_FLAGS " -wx")  # warning level: to maximum setting
     
-    if(WATCOM_DOS32)
-        string(APPEND CMAKE_C_FLAGS " -mf")  # memory model: options are flat (-mf), large (-ml), memdium (-mm), small (-ms)
-    else()
+    if(WATCOM_DOS16)
         string(APPEND CMAKE_C_FLAGS " -ml")  # memory model: options are large (-ml), memdium (-mm), small (-ms)
+    else()
+        string(APPEND CMAKE_C_FLAGS " -mf")  # memory model: options are flat (-mf), large (-ml), memdium (-mm), small (-ms)
     endif()
 
     string(APPEND CMAKE_C_FLAGS_RELEASE " -oneatx")

--- a/vt/CMakeLists.txt
+++ b/vt/CMakeLists.txt
@@ -9,6 +9,17 @@ PROJECT(vt VERSION "${PROJECT_VERSION}" LANGUAGES C)
 
 INCLUDE(project_common)
 
+if(DOS)
+    string(APPEND CMAKE_C_FLAGS " -DDOS")
+endif()
+
+if(WATCOM)
+    if(WATCOM_DOS16)
+        string(APPEND CMAKE_C_FLAGS " -ml")  # memory model: options are large (-ml), memdium (-mm), small (-ms)
+    else()
+        string(APPEND CMAKE_C_FLAGS " -mf")  # memory model: options are flat (-mf), large (-ml), memdium (-mm), small (-ms)
+    endif()
+endif()
 
 demo_app(../demos firework)
 demo_app(../demos ozdemo)


### PR DESCRIPTION
only DOS 16-bit build uses large memory model
other targets are 32-bit and flat memory model