### PR TITLE
wingui: Fix painting of edges when started maximized; improve icon loading

### DIFF
--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -6,7 +6,6 @@
 #include <assert.h>
 #include "../common/pdccolor.h"
 #ifdef WIN32_LEAN_AND_MEAN
-   #include <shellapi.h>
    #include <stdlib.h>
 #endif
 
@@ -1019,20 +1018,26 @@ static void get_app_name( TCHAR *buff, const size_t buff_size, const bool includ
     my_tcslwr( buff + 1);
 }
 
+/* Ensure compatibility with old compilers that don't support 64-bit targets. */
+#ifndef MAXLONG_PTR
+#define LONG_PTR LONG
+#endif
+
+BOOL CALLBACK get_app_icon_callback(HMODULE hModule, LPCTSTR lpszType,
+                                    LPTSTR lpszName, LONG_PTR lParam)
+{
+    *((HICON *) lParam) = LoadIcon(hModule, lpszName);
+    return FALSE; /* stop enumeration after first icon */
+}
+
 /* This function extracts the first icon from the executable that is
 executing this DLL */
 
-INLINE HICON get_app_icon( )
+INLINE HICON get_app_icon( HANDLE hModule)
 {
-#ifdef PDC_WIDE
-    wchar_t filename[MAX_PATH];
-#else
-    char filename[MAX_PATH];
-#endif
-
     HICON icon = NULL;
-    if ( GetModuleFileName( NULL, filename, sizeof(filename) ) != 0 )
-       icon = ExtractIcon( 0, filename, 0 );
+    EnumResourceNames(hModule, RT_GROUP_ICON,
+                      get_app_icon_callback, (LONG_PTR) &icon);
     return icon;
 }
 
@@ -1926,10 +1931,7 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
       /* refresh.c.  I'm not entirely sure that this is what ought to be  */
       /* done,  though it does appear to work correctly.                  */
     case WM_PAINT:
-        if( hwnd && curscr )
-        {
-            HandlePaint( hwnd );
-        }
+        HandlePaint( hwnd );
         break;
 
     case WM_KEYUP:
@@ -2145,7 +2147,7 @@ INLINE int set_up_window( void)
     /* create the dialog window  */
     WNDCLASS   wndclass ;
     HMENU hMenu;
-    HANDLE hInstance = GetModuleHandleA( NULL);
+    HANDLE hInstance = GetModuleHandle( NULL);
     int n_default_columns = 80;
     int n_default_rows = 25;
     int xsize, ysize, window_style;
@@ -2161,7 +2163,7 @@ INLINE int set_up_window( void)
     originally_focussed_window = GetForegroundWindow( );
     debug_printf( "hInstance %x\nOriginal window %x\n", hInstance, originally_focussed_window);
     /* set the window icon from the icon in the process */
-    icon = get_app_icon();
+    icon = get_app_icon(hInstance);
     if( !icon )
        icon = LoadIcon( NULL, IDI_APPLICATION);
     if( !wndclass_has_been_registered)
@@ -2250,7 +2252,6 @@ INLINE int set_up_window( void)
     ShowWindow (PDC_hWnd,
                     (n_default_columns == -1) ? SW_SHOWMAXIMIZED : SW_SHOWNORMAL);
     debug_printf( "window shown\n");
-    ValidateRect( PDC_hWnd, NULL);       /* don't try repainting */
     UpdateWindow (PDC_hWnd) ;
     debug_printf( "window updated\n");
     SetTimer( PDC_hWnd, TIMER_ID_FOR_BLINKING, 500, NULL);

--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -6,7 +6,9 @@
 #include <assert.h>
 #include "../common/pdccolor.h"
 #ifdef WIN32_LEAN_AND_MEAN
-   #include <shellapi.h>
+   #ifdef PDC_WIDE
+      #include <shellapi.h>
+   #endif
    #include <stdlib.h>
 #endif
 

--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -1026,8 +1026,8 @@ static void get_app_name( TCHAR *buff, const size_t buff_size, const bool includ
 #define LONG_PTR LONG
 #endif
 
-BOOL CALLBACK get_app_icon_callback(HMODULE hModule, LPCTSTR lpszType,
-                                    LPTSTR lpszName, LONG_PTR lParam)
+static BOOL CALLBACK get_app_icon_callback(HMODULE hModule, LPCTSTR lpszType,
+                                           LPTSTR lpszName, LONG_PTR lParam)
 {
     *((HICON *) lParam) = LoadIcon(hModule, lpszName);
     return FALSE; /* stop enumeration after first icon */

--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -6,6 +6,7 @@
 #include <assert.h>
 #include "../common/pdccolor.h"
 #ifdef WIN32_LEAN_AND_MEAN
+   #include <shellapi.h>
    #include <stdlib.h>
 #endif
 

--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -1019,7 +1019,7 @@ static void get_app_name( TCHAR *buff, const size_t buff_size, const bool includ
 }
 
 /* Ensure compatibility with old compilers that don't support 64-bit targets. */
-#ifndef MAXLONG_PTR
+#if !defined(_BASETSD_H_) && !defined(_BASETSD_H)
 #define LONG_PTR LONG
 #endif
 


### PR DESCRIPTION
Currently, if a WinGUI program is started maximized (because it was last closed while maximized), the edges of the window (not covered by the Curses screen) will not be filled in. This patch fixes this by removing the `ValidateRect()` call in `set_up_window()`, which prevented any `WM_PAINT` messages from being sent at startup, and removing the window procedure's (redundant) check of `curscr` before calling `HandlePaint()`. (I also removed the `if` block altogether; when would the window procedure ever be called with a null `HWND`?)

Also, WinGUI currently uses `ExtractIcon()` to load the first icon (if present) in the application's executable. Ostensibly this function would be fine for the job, but it only seems to load a standard-size (e.g. 32 x 32) icon, potentially resulting in a relatively ugly icon in the title bar even if the icon group contained a proper smaller icon.

Using `LoadIcon()` would be better, as it loads the icon group correctly (at least when not loading a "standard" icon with a null module handle), but it requires that one supply the name/ID (not index) of the icon group resource, which is application-defined.

After considering and experimenting with other icon-related functions, I settled on the solution here, wherein we use `EnumResourceNames()`, passing a corresponding callback function and a pointer to the `icon` variable as the `lParam`. If the executable contains any icon groups, it will call our callback function with the name of the first one and our `lParam`, which then calls `LoadIcon()`. (I did some testing and `EnumResourceNames()` apparently does use the same order as, e.g., Windows Explorer uses to pick the first icon.)

Before: :-1:
![PDCurses_wingui_icon_before](https://user-images.githubusercontent.com/66034630/84604124-d2357180-ae61-11ea-8b66-66d792b266c7.png)

After: :+1:
![PDCurses_wingui_icon_after](https://user-images.githubusercontent.com/66034630/84604132-e0838d80-ae61-11ea-80dc-0c8322f5738e.png)

As a bonus, this solution has the side effect of removing any usage of shell32.dll functions (EDIT: in non-Unicode builds)~~, so I removed the `#include <shellapi.h>` statement~~.