### PR TITLE
wingui: Restrict font dialog to compatible fonts

### DIFF
--- a/wingui/pdcdisp.c
+++ b/wingui/pdcdisp.c
@@ -248,10 +248,9 @@ int PDC_choose_a_new_font( void)
     debug_printf( "In PDC_choose_a_new_font: %d\n", lf.lfHeight);
     memset( &cf, 0, sizeof( CHOOSEFONT));
     cf.lStructSize = sizeof( CHOOSEFONT);
-    cf.Flags = CF_INITTOLOGFONTSTRUCT | CF_SCREENFONTS;
+    cf.Flags = CF_INITTOLOGFONTSTRUCT | CF_SCREENFONTS | CF_FIXEDPITCHONLY | CF_SELECTSCRIPT;
     cf.hwndOwner = PDC_hWnd;
     cf.lpLogFont = &lf;
-    cf.rgbColors = RGB( 0, 0, 0);
     rval = ChooseFont( &cf);
     if( rval)
 #ifdef PDC_WIDE


### PR DESCRIPTION
Currently, a user is allowed to choose a proportional/non-monospace font, which will work but with messy results. Also, one can choose a script (character set). The `LOGFONT` structure returned by `PDC_get_logical_font()` always has the `lfCharSet` member set to `ANSI_CHARSET`, so selecting a different script with a font that's also `ANSI_CHARSET` compatible will have no effect, and a font that isn't compatible with `ANSI_CHARSET` (e.g. Terminal, and other "OEM/DOS" fonts) will fail to be used altogether when drawing the screen.

This patch adds `CF_FIXEDPITCHONLY` and `CF_SELECTSCRIPT` to the flags passed to `ChooseFont()` in `PDC_choose_a_new_font()`, so the font dialog will only list fixed-width/monospace fonts compatible with `ANSI_CHARSET`.

I also removed the assignment of the `CHOOSEFONT` structure's `cf.rgbColors` member, which as far as I can tell was pointless because the `CF_EFFECTS` flag is not being used.

Patch tested on Windows NT 4.0 and Vista.

(The user's style selection in the font dialog is also ignored, but there isn't a (simple) way to limit this as far as I can tell. The closest I found was setting the `CF_NOSIMULATIONS` flag, which excludes the bold and italic options only with fonts without built-in support for them.)

(Ideally, it would be nice to allow "OEM/DOS" fonts to be used as well, but this would require the drawing code to be modified to handle them, and we wouldn't be able to filter out non-ANSI, non-OEM, non-symbol scripts in the font dialog unless we implemented a separate "Choose Font" menu option for `OEM_CHARSET` fonts.)