### PR TITLE
wingui: Fix MinGW makefile

### DIFF
--- a/wingui/Makefile.mng
+++ b/wingui/Makefile.mng
@@ -6,13 +6,14 @@
 # [all|demos|pdcurses.a|testcurs.exe...]
 
 O = o
+E = .exe
 
 ifndef PDCURSES_SRCDIR
 	PDCURSES_SRCDIR = ..
 endif
 
 include $(PDCURSES_SRCDIR)/version.mif
-include $(PDCURSES_SRCDIR)/libobjs.mif
+include $(PDCURSES_SRCDIR)/common/libobjs.mif
 
 uname_S := $(shell uname -s 2>/dev/null)
 


### PR DESCRIPTION
Commit b754e9862bc79720df6888b1fa955f9662d972dc missed updating WinGUI's MinGW/GCC makefile to use the libobjs.mif in the common directory. This pull request fixes this.