### PR TITLE
wingui: Move window procedure to separate thread to fix hanging/ugliness during resize/move

### DIFF
--- a/wingui/pdcdisp.c
+++ b/wingui/pdcdisp.c
@@ -243,6 +243,7 @@ int PDC_choose_a_new_font( void)
     CHOOSEFONT cf;
     int rval;
     extern HWND PDC_hWnd;
+    extern CRITICAL_SECTION PDC_cs;
 
     lf.lfHeight = -PDC_font_size;
     debug_printf( "In PDC_choose_a_new_font: %d\n", lf.lfHeight);
@@ -251,16 +252,19 @@ int PDC_choose_a_new_font( void)
     cf.Flags = CF_INITTOLOGFONTSTRUCT | CF_SCREENFONTS | CF_FIXEDPITCHONLY | CF_SELECTSCRIPT;
     cf.hwndOwner = PDC_hWnd;
     cf.lpLogFont = &lf;
+    LeaveCriticalSection(&PDC_cs);
     rval = ChooseFont( &cf);
-    if( rval)
+    EnterCriticalSection(&PDC_cs);
+    if( rval) {
 #ifdef PDC_WIDE
         wcscpy( PDC_font_name, lf.lfFaceName);
 #else
         strcpy( PDC_font_name, lf.lfFaceName);
 #endif
+        PDC_font_size = -lf.lfHeight;
+        debug_printf( "output size: %d\n", lf.lfHeight);
+    }
     debug_printf( "rval %d; %ld\n", rval, CommDlgExtendedError( ));
-    debug_printf( "output size: %d\n", lf.lfHeight);
-    PDC_font_size = -lf.lfHeight;
     return( rval);
 }
 

--- a/wingui/pdckbd.c
+++ b/wingui/pdckbd.c
@@ -15,14 +15,8 @@ void PDC_set_keyboard_binary(bool on)
 extern int PDC_key_queue_low, PDC_key_queue_high;
 extern int PDC_key_queue[KEY_QUEUE_SIZE];
 
-/* PDCurses message/event callback */
-/* Calling PDC_napms for one millisecond ensures that the message loop */
-/* is called and messages in general,  and keyboard events in particular, */
-/* get processed.   */
-
 bool PDC_check_key(void)
 {
-    PDC_napms( 1);
     if( PDC_key_queue_low != PDC_key_queue_high)
         return TRUE;
     return FALSE;

--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -2476,8 +2476,8 @@ int PDC_resize_screen( int nlines, int ncols)
 
         if( new_width != client_rect.right || new_height != client_rect.bottom)
         {                    /* check to make sure size actually changed */
-            add_resize_key = 0;
             DWORD thr_id = GetCurrentThreadId();
+            add_resize_key = 0;
 
             if (thr_id != winthr_id)
                 LeaveCriticalSection(&PDC_cs);

--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -1877,53 +1877,47 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
         EnterCriticalSection(&PDC_cs);
         if( HandleMouseMove( wParam, lParam))
             modified_key_to_return = 0;
-        break;
+        add_mouse( -1, -1, -1, -1);
+        LeaveCriticalSection(&PDC_cs);
+        return 0;
 
     case WM_LBUTTONDOWN:
-        EnterCriticalSection(&PDC_cs);
         button = 1;
         action = BUTTON_PRESSED;
         break;
 
     case WM_LBUTTONUP:
-        EnterCriticalSection(&PDC_cs);
         button = 1;
         action = BUTTON_RELEASED;
         break;
 
     case WM_RBUTTONDOWN:
-        EnterCriticalSection(&PDC_cs);
         button = 3;
         action = BUTTON_PRESSED;
         break;
 
     case WM_RBUTTONUP:
-        EnterCriticalSection(&PDC_cs);
         button = 3;
         action = BUTTON_RELEASED;
         break;
 
     case WM_MBUTTONDOWN:
-        EnterCriticalSection(&PDC_cs);
         button = 2;
         action = BUTTON_PRESSED;
         break;
 
     case WM_MBUTTONUP:
-        EnterCriticalSection(&PDC_cs);
         button = 2;
         action = BUTTON_RELEASED;
         break;
 
     case WM_XBUTTONDOWN:
-        EnterCriticalSection(&PDC_cs);
         button = ((wParam & MK_XBUTTON1) ? 3 : 4);
         action = BUTTON_PRESSED;
         xbutton_pressed = button;
         break;
 
     case WM_XBUTTONUP:
-        EnterCriticalSection(&PDC_cs);
 #ifdef WRONG_WAY
           /* You'd think we'd use the following line,  wouldn't you?      */
           /* But we can't,  because an XBUTTONUP message doesn't actually */
@@ -2009,7 +2003,9 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
             /* blink the blinking text */
             HandleTimer( wParam );
         }
-        break;
+        add_mouse( -1, -1, -1, -1);
+        LeaveCriticalSection(&PDC_cs);
+        return 0;
 
     case WM_CLOSE:
         EnterCriticalSection(&PDC_cs);
@@ -2070,20 +2066,18 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
         return DefWindowProc( hwnd, message, wParam, lParam) ;
     }
 
-    /* mouse handling code */
-    if( button != -1)
-    {
-        add_mouse( button, action, LOWORD( lParam) / PDC_cxChar, HIWORD( lParam) / PDC_cyChar);
-        if( action == BUTTON_PRESSED)
-           SetCapture( hwnd);
-        else
-           ReleaseCapture( );
-#if 0 /* checkme */
-        SetTimer( hwnd, 0, SP->mouse_wait, NULL);
-#endif
-    }
+    /* mouse button handling code */
+    assert( button != -1);
+    EnterCriticalSection(&PDC_cs);
+
+    add_mouse( button, action, LOWORD( lParam) / PDC_cxChar, HIWORD( lParam) / PDC_cyChar);
+    if( action == BUTTON_PRESSED)
+       SetCapture( hwnd);
     else
-       add_mouse( -1, -1, -1, -1);
+       ReleaseCapture( );
+#if 0 /* checkme */
+    SetTimer( hwnd, 0, SP->mouse_wait, NULL);
+#endif
 
     LeaveCriticalSection(&PDC_cs);
     return 0;

--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -4,6 +4,7 @@
 #include <tchar.h>
 #include <stdint.h>
 #include <assert.h>
+#include <process.h>
 #include "../common/pdccolor.h"
 #ifdef WIN32_LEAN_AND_MEAN
    #ifdef PDC_WIDE
@@ -66,7 +67,7 @@ cube of 16 million colors. */
 int PDC_show_ctrl_alts = 0;
 
 /* RR: Removed statis on next line */
-bool PDC_bDone = FALSE;
+/*bool PDC_bDone = FALSE;*/
 static HWND originally_focussed_window;
 
 int debug_printf( const char *format, ...)
@@ -105,6 +106,8 @@ int debug_printf( const char *format, ...)
 HWND PDC_hWnd;
 static int PDC_argc = 0;
 static char **PDC_argv = NULL;
+uint32_t winthr_id = 0;
+CRITICAL_SECTION PDC_cs;
 
 static void final_cleanup( void)
 {
@@ -141,7 +144,7 @@ void PDC_scr_close(void)
 {
     PDC_LOG(("PDC_scr_close() - called\n"));
     final_cleanup( );
-    PDC_bDone = TRUE;
+    /*PDC_bDone = TRUE;*/
 }
 
 /* NOTE that PDC_scr_free( ) is called only from delscreen( ),    */
@@ -1836,11 +1839,6 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
     static bool ignore_resize = FALSE;
     int button = -1, action = -1;
 
-    PDC_hWnd = hwnd;
-    if( !hwnd)
-        debug_printf( "Null hWnd: msg %u, wParam %x, lParam %lx\n",
-                     message, wParam, lParam);
-
     switch (message)
     {
     case WM_SIZING:
@@ -1850,12 +1848,16 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
     case WM_SIZE:
                 /* If ignore_resize = 1,  don't bother resizing; */
                 /* the final window size has yet to be set       */
-        if( ignore_resize == FALSE)
-           HandleSize( wParam, lParam);
+        if( ignore_resize == FALSE) {
+            EnterCriticalSection(&PDC_cs);
+            HandleSize( wParam, lParam);
+            LeaveCriticalSection(&PDC_cs);
+        }
         return 0 ;
 
     case WM_MOUSEWHEEL:
     case WM_MOUSEHWHEEL:
+        EnterCriticalSection(&PDC_cs);
         {
             POINT pt;
 
@@ -1871,47 +1873,56 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
         break;
 
     case WM_MOUSEMOVE:
+        EnterCriticalSection(&PDC_cs);
         if( HandleMouseMove( wParam, lParam))
             modified_key_to_return = 0;
         break;
 
     case WM_LBUTTONDOWN:
+        EnterCriticalSection(&PDC_cs);
         button = 1;
         action = BUTTON_PRESSED;
         break;
 
     case WM_LBUTTONUP:
+        EnterCriticalSection(&PDC_cs);
         button = 1;
         action = BUTTON_RELEASED;
         break;
 
     case WM_RBUTTONDOWN:
+        EnterCriticalSection(&PDC_cs);
         button = 3;
         action = BUTTON_PRESSED;
         break;
 
     case WM_RBUTTONUP:
+        EnterCriticalSection(&PDC_cs);
         button = 3;
         action = BUTTON_RELEASED;
         break;
 
     case WM_MBUTTONDOWN:
+        EnterCriticalSection(&PDC_cs);
         button = 2;
         action = BUTTON_PRESSED;
         break;
 
     case WM_MBUTTONUP:
+        EnterCriticalSection(&PDC_cs);
         button = 2;
         action = BUTTON_RELEASED;
         break;
 
     case WM_XBUTTONDOWN:
+        EnterCriticalSection(&PDC_cs);
         button = ((wParam & MK_XBUTTON1) ? 3 : 4);
         action = BUTTON_PRESSED;
         xbutton_pressed = button;
         break;
 
     case WM_XBUTTONUP:
+        EnterCriticalSection(&PDC_cs);
 #ifdef WRONG_WAY
           /* You'd think we'd use the following line,  wouldn't you?      */
           /* But we can't,  because an XBUTTONUP message doesn't actually */
@@ -1934,11 +1945,13 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
       /* refresh.c.  I'm not entirely sure that this is what ought to be  */
       /* done,  though it does appear to work correctly.                  */
     case WM_PAINT:
+        EnterCriticalSection(&PDC_cs);
         HandlePaint( hwnd );
         break;
 
     case WM_KEYUP:
     case WM_SYSKEYUP:
+        EnterCriticalSection(&PDC_cs);
         if( wParam == VK_MENU && numpad_unicode_value)
         {
             modified_key_to_return = numpad_unicode_value;
@@ -1953,6 +1966,7 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
         break;
 
     case WM_CHAR:       /* _Don't_ add Shift-Tab;  it's handled elsewhere */
+        EnterCriticalSection(&PDC_cs);
         if( wParam == 3 && !SP->raw_inp)     /* Ctrl-C hit */
             exit( 0);
         if( wParam != 9 || !(GetKeyState( VK_SHIFT) & 0x8000))
@@ -1965,7 +1979,9 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
     case WM_SYSKEYDOWN:
         if( wParam < 225 && wParam > 0 )
         {
+            EnterCriticalSection(&PDC_cs);
             HandleSyskeyDown( wParam, lParam, &modified_key_to_return );
+            LeaveCriticalSection(&PDC_cs);
         }
         return 0 ;
 
@@ -1973,6 +1989,7 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
         return 0 ;
 
     case WM_TIMER:
+        EnterCriticalSection(&PDC_cs);
         if( wParam != TIMER_ID_FOR_BLINKING)
         {
             KillTimer( PDC_hWnd, (int)wParam);
@@ -1988,35 +2005,39 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
         break;
 
     case WM_CLOSE:
+        EnterCriticalSection(&PDC_cs);
+        if( !PDC_shutdown_key[FUNCTION_KEY_SHUT_DOWN])
         {
-            if( !PDC_shutdown_key[FUNCTION_KEY_SHUT_DOWN])
-            {
-                final_cleanup( );
-                PDC_bDone = TRUE;
-                exit( 0);
-            }
-            else
-                add_key_to_queue( PDC_shutdown_key[FUNCTION_KEY_SHUT_DOWN]);
+            final_cleanup( );
+            /*PDC_bDone = TRUE;*/
+            exit( 0);
         }
+        else
+            add_key_to_queue( PDC_shutdown_key[FUNCTION_KEY_SHUT_DOWN]);
+
+        LeaveCriticalSection(&PDC_cs);
         return( 0);
 
     case WM_COMMAND:
     case WM_SYSCOMMAND:
+        EnterCriticalSection(&PDC_cs);
         if( wParam == WM_EXIT_GRACELESSLY)
         {
             final_cleanup( );
-            PDC_bDone = TRUE;
+            /*PDC_bDone = TRUE;*/
             exit( 0);
         }
         else if( wParam == WM_ENLARGE_FONT || wParam == WM_SHRINK_FONT)
         {
             adjust_font_size( (wParam == WM_ENLARGE_FONT) ? 1 : -1);
+            LeaveCriticalSection(&PDC_cs);
             return( 0);
         }
         else if( wParam == WM_CHOOSE_FONT)
         {
             if( PDC_choose_a_new_font( ))
                 adjust_font_size( 0);
+            LeaveCriticalSection(&PDC_cs);
             return( 0);
         }
         else if( wParam == WM_TOGGLE_MENU)
@@ -2026,10 +2047,15 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
         break;
 
     case WM_DESTROY:
+        EnterCriticalSection(&PDC_cs);
         PDC_LOG(("WM_DESTROY\n"));
         PostQuitMessage (0) ;
-        PDC_bDone = TRUE;
+        /*PDC_bDone = TRUE;*/
+        LeaveCriticalSection(&PDC_cs);
         return 0 ;
+
+    default:
+        EnterCriticalSection(&PDC_cs);
     }
     if( button != -1)
     {
@@ -2044,6 +2070,8 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
     }
     else
        add_mouse( -1, -1, -1, -1);
+
+    LeaveCriticalSection(&PDC_cs);
     return DefWindowProc( hwnd, message, wParam, lParam) ;
 }
 
@@ -2125,6 +2153,77 @@ static void clip_or_center_window_to_monitor( HWND hwnd)
 }
 #endif
 
+struct PDC_WININFO {
+    HANDLE hInstance;
+    int xsize;
+    int ysize;
+    int window_style;
+    int xloc;
+    int yloc;
+    TCHAR WindowTitle[MAX_PATH];
+};
+
+const TCHAR *AppName = _T( "Curses_App");
+HANDLE winthr_ready;
+
+/* Thread that creates and manages the WinGUI window.
+   The return type (and declared type of winthr_id) is uint32_t instead of
+   DWORD to avoid compiler warnings. */
+
+static uint32_t WINAPI window_thread(LPVOID lpParameter)
+{
+    MSG msg;
+    HMENU hMenu;
+    struct PDC_WININFO *winfo = (struct PDC_WININFO *) lpParameter;
+    BOOL rval;
+
+    PDC_hWnd = CreateWindow( AppName, winfo->WindowTitle, winfo->window_style,
+                    winfo->xloc, winfo->yloc,
+                    winfo->xsize, winfo->ysize,
+                    NULL, (menu_shown ? set_menu( ) : NULL),
+                    winfo->hInstance, NULL) ;
+
+    if( !PDC_hWnd)
+    {
+        const DWORD last_error = GetLastError( );
+
+        debug_printf( "CreateWindow failed; GetLastError = %ld", last_error);
+        return( 2);
+    }
+
+    hMenu = GetSystemMenu( PDC_hWnd, FALSE);
+    AppendMenu( hMenu, MF_STRING | (menu_shown ? MF_CHECKED : MF_UNCHECKED), WM_TOGGLE_MENU, _T( "Menu"));
+    AppendMenu( hMenu, MF_STRING, WM_CHOOSE_FONT, _T( "Choose Font"));
+
+    debug_printf( "menu set\n");
+
+    ShowWindow (PDC_hWnd,
+                    (winfo->window_style & WS_MAXIMIZE) ? SW_SHOWMAXIMIZED : SW_SHOWNORMAL);
+    debug_printf( "window shown\n");
+    UpdateWindow (PDC_hWnd) ;
+    debug_printf( "window updated\n");
+    SetTimer( PDC_hWnd, TIMER_ID_FOR_BLINKING, 500, NULL);
+    debug_printf( "timer set\n");
+
+#if defined( MONITOR_DEFAULTTONEAREST) && WINVER >= 0x0410
+    /* if the window is off-screen, move it on screen. */
+    clip_or_center_window_to_monitor( PDC_hWnd);
+#endif
+
+    SetEvent(winthr_ready);
+
+    while ((rval = GetMessage(&msg, NULL, 0, 0)) == TRUE) {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+    }
+
+    if (rval == -1) {
+        debug_printf("GetMessage() error: GetLastError = %lu\n", GetLastError());
+        return 1;
+    }
+    return 0;
+}
+
 /* By default,  the user cannot resize the window.  This is because
 many apps don't handle KEY_RESIZE,  and one can get odd behavior
 in such cases.  There are two ways around this.  If you call
@@ -2149,29 +2248,33 @@ INLINE int set_up_window( void)
 {
     /* create the dialog window  */
     WNDCLASS   wndclass ;
-    HMENU hMenu;
     HANDLE hInstance = GetModuleHandle( NULL);
     int n_default_columns = 80;
     int n_default_rows = 25;
-    int xsize, ysize, window_style;
-    int xloc = CW_USEDEFAULT;
-    int yloc = CW_USEDEFAULT;
-    TCHAR WindowTitle[MAX_PATH];
-    const TCHAR *AppName = _T( "Curses_App");
+    struct PDC_WININFO winfo;
     HICON icon;
-    static bool wndclass_has_been_registered = FALSE;
+    /*static bool wndclass_has_been_registered = FALSE;*/
+    HANDLE winthr_h;
+    HANDLE hWait[2];
+    DWORD winthr_status;
 
     if( !hInstance)
         debug_printf( "No instance: %d\n", GetLastError( ));
+
+    winfo.hInstance = hInstance;
+    winfo.xloc = CW_USEDEFAULT;
+    winfo.yloc = CW_USEDEFAULT;
+
     originally_focussed_window = GetForegroundWindow( );
     debug_printf( "hInstance %x\nOriginal window %x\n", hInstance, originally_focussed_window);
-    /* set the window icon from the icon in the process */
-    icon = get_app_icon(hInstance);
-    if( !icon )
-       icon = LoadIcon( NULL, IDI_APPLICATION);
-    if( !wndclass_has_been_registered)
+    /*if( !wndclass_has_been_registered)*/
     {
         ATOM rval;
+
+        /* set the window icon from the icon in the process */
+        icon = get_app_icon(hInstance);
+        if( !icon )
+           icon = LoadIcon( NULL, IDI_APPLICATION);
 
         wndclass.style         = CS_VREDRAW ;
         wndclass.lpfnWndProc   = WndProc ;
@@ -2192,16 +2295,17 @@ INLINE int set_up_window( void)
             debug_printf( "RegisterClass failed: GetLastError = %lx\n", last_error);
             return( -1);
         }
-        wndclass_has_been_registered = TRUE;
+        /*wndclass_has_been_registered = TRUE;*/
     }
 
-    get_app_name( WindowTitle, MAX_PATH, TRUE);
+    get_app_name( winfo.WindowTitle, MAX_PATH, TRUE);
 #ifdef PDC_WIDE
-    debug_printf( "WindowTitle = '%ls'\n", WindowTitle);
+    debug_printf( "WindowTitle = '%ls'\n", winfo.WindowTitle);
 #endif
 
-    get_default_sizes_from_registry( &n_default_columns, &n_default_rows, &xloc, &yloc,
-                     &menu_shown);
+    get_default_sizes_from_registry( &n_default_columns, &n_default_rows,
+                                     &winfo.xloc, &winfo.yloc,
+                                     &menu_shown);
     if( PDC_n_rows > 2 && PDC_n_cols > 2)
     {
         n_default_columns = PDC_n_cols;
@@ -2213,57 +2317,52 @@ INLINE int set_up_window( void)
                                (unsigned char)ttytype[2],
                                (unsigned char)ttytype[3]);
     debug_printf( "Size %d x %d,  loc %d x %d;  menu %d\n",
-               n_default_columns, n_default_rows, xloc, yloc, menu_shown);
+               n_default_columns, n_default_rows, winfo.xloc, winfo.yloc, menu_shown);
     get_character_sizes( NULL, &PDC_cxChar, &PDC_cyChar);
 
     if( min_lines != max_lines || min_cols != max_cols)
-        window_style = ((n_default_columns == -1) ?
+        winfo.window_style = ((n_default_columns == -1) ?
                     WS_MAXIMIZE | WS_OVERLAPPEDWINDOW : WS_OVERLAPPEDWINDOW);
     else  /* fixed-size window:  looks "normal",  but w/o a maximize box */
-        window_style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX;
+        winfo.window_style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX;
 
     if( n_default_columns == -1)
-        xsize = ysize = CW_USEDEFAULT;
+        winfo.xsize = winfo.ysize = CW_USEDEFAULT;
     else
     {
         keep_size_within_bounds( &n_default_rows, &n_default_columns);
-        xsize = PDC_cxChar * n_default_columns;
-        ysize = PDC_cyChar * n_default_rows;
-        adjust_window_size( &xsize, &ysize, window_style, menu_shown);
+        winfo.xsize = PDC_cxChar * n_default_columns;
+        winfo.ysize = PDC_cyChar * n_default_rows;
+        adjust_window_size( &winfo.xsize, &winfo.ysize, winfo.window_style, menu_shown);
     }
 
-    PDC_hWnd = CreateWindow( AppName, WindowTitle, window_style,
-                    xloc, yloc,
-                    xsize, ysize,
-                    NULL, (menu_shown ? set_menu( ) : NULL),
-                    hInstance, NULL) ;
-
-    if( !PDC_hWnd)
-    {
-        const DWORD last_error = GetLastError( );
-
-        debug_printf( "CreateWindow failed; GetLastError = %ld", last_error);
-        return( -2);
+    InitializeCriticalSection(&PDC_cs);
+    winthr_ready = CreateEvent(NULL, FALSE, FALSE, NULL);
+    winthr_h = (HANDLE) _beginthreadex(NULL, 0, window_thread, &winfo, 0, &winthr_id);
+    if (winthr_h == (HANDLE) 0) {
+        debug_printf("_beginthreadex() failed: %s\n", strerror(errno));
+        DeleteCriticalSection(&PDC_cs);
+        CloseHandle(winthr_ready);
+        CloseHandle(winthr_h);
+        return -1;
     }
 
-    hMenu = GetSystemMenu( PDC_hWnd, FALSE);
-    AppendMenu( hMenu, MF_STRING | (menu_shown ? MF_CHECKED : MF_UNCHECKED), WM_TOGGLE_MENU, _T( "Menu"));
-    AppendMenu( hMenu, MF_STRING, WM_CHOOSE_FONT, _T( "Choose Font"));
-
-    debug_printf( "menu set\n");
-
-    ShowWindow (PDC_hWnd,
-                    (n_default_columns == -1) ? SW_SHOWMAXIMIZED : SW_SHOWNORMAL);
-    debug_printf( "window shown\n");
-    UpdateWindow (PDC_hWnd) ;
-    debug_printf( "window updated\n");
-    SetTimer( PDC_hWnd, TIMER_ID_FOR_BLINKING, 500, NULL);
-    debug_printf( "timer set\n");
-
-#if defined( MONITOR_DEFAULTTONEAREST) && WINVER >= 0x0410
-    /* if the window is off-screen, move it on screen. */
-    clip_or_center_window_to_monitor( PDC_hWnd);
-#endif
+    hWait[0] = winthr_ready;
+    hWait[1] = winthr_h;
+    WaitForMultipleObjects(2, hWait, FALSE, INFINITE);
+    CloseHandle(winthr_ready);
+    if (!GetExitCodeThread(winthr_h, &winthr_status)) {
+        debug_printf("GetExitCodeThread() failed: GetLastError = %lu\n", GetLastError());
+        DeleteCriticalSection(&PDC_cs);
+        CloseHandle(winthr_h);
+        return -1;
+    }
+    CloseHandle(winthr_h);
+    if (winthr_status != STILL_ACTIVE) {
+        debug_printf("Premature window_thread termination: exit code = %lu\n", winthr_status);
+        DeleteCriticalSection(&PDC_cs);
+        return winthr_status;
+    }
 
     return( 0);
 }
@@ -2328,6 +2427,8 @@ int PDC_scr_open(void)
     while( !PDC_get_rows( ))     /* wait for screen to be drawn and */
       ;                          /* actual size to be determined    */
 
+    EnterCriticalSection(&PDC_cs);
+
     debug_printf( "Back from PDC_get_rows\n");
     SP->lines = PDC_get_rows();
     SP->cols = PDC_get_columns();
@@ -2376,10 +2477,18 @@ int PDC_resize_screen( int nlines, int ncols)
         if( new_width != client_rect.right || new_height != client_rect.bottom)
         {                    /* check to make sure size actually changed */
             add_resize_key = 0;
+            DWORD thr_id = GetCurrentThreadId();
+
+            if (thr_id != winthr_id)
+                LeaveCriticalSection(&PDC_cs);
+
             SetWindowPos( PDC_hWnd, 0, 0, 0,
                    new_width + (rect.right - rect.left) - client_rect.right,
                    new_height + (rect.bottom - rect.top) - client_rect.bottom,
                   SWP_NOMOVE | SWP_NOZORDER | SWP_SHOWWINDOW);
+
+            if (thr_id != winthr_id)
+                EnterCriticalSection(&PDC_cs);
         }
     }
     return OK;

--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -2163,8 +2163,8 @@ struct PDC_WININFO {
     TCHAR WindowTitle[MAX_PATH];
 };
 
-const TCHAR *AppName = _T( "Curses_App");
-HANDLE winthr_ready;
+static const TCHAR *AppName = _T( "Curses_App");
+static HANDLE winthr_ready;
 
 /* Thread that creates and manages the WinGUI window.
    The return type (and declared type of winthr_id) is uint32_t instead of

--- a/wingui/pdcsetsc.c
+++ b/wingui/pdcsetsc.c
@@ -59,17 +59,20 @@ int PDC_curs_set(int visibility)
 void PDC_set_title(const char *title)
 {
     extern HWND PDC_hWnd;
+    extern CRITICAL_SECTION PDC_cs;
 #ifdef PDC_WIDE
     wchar_t wtitle[512];
 #endif
     PDC_LOG(("PDC_set_title() - called:<%s>\n", title));
 
+    LeaveCriticalSection(&PDC_cs);
 #ifdef PDC_WIDE
     PDC_mbstowcs(wtitle, title, 511);
     SetWindowTextW( PDC_hWnd, wtitle);
 #else
     SetWindowTextA( PDC_hWnd, title);
 #endif
+    EnterCriticalSection(&PDC_cs);
 }
 
         /* If SP->termattrs & A_BLINK is on, then text with the A_BLINK  */

--- a/wingui/pdcutil.c
+++ b/wingui/pdcutil.c
@@ -13,31 +13,13 @@ void PDC_beep(void)
 void PDC_napms(int ms)     /* 'ms' = milli,  _not_ microseconds! */
 {
     /* RR: keep GUI window responsive while PDCurses sleeps */
-    MSG msg;
-    DWORD curr_ms = GetTickCount( );
-    const DWORD milliseconds_sleep_limit = ms + curr_ms;
-    extern bool PDC_bDone;
+    extern CRITICAL_SECTION PDC_cs;
 
     PDC_LOG(("PDC_napms() - called: ms=%d\n", ms));
 
-    /* Pump all pending messages from WIN32 to the window handler */
-    while( !PDC_bDone && curr_ms < milliseconds_sleep_limit )
-    {
-        const DWORD max_sleep_ms = 50;      /* check msgs 20 times/second */
-        DWORD sleep_millisecs;
-
-        while( PeekMessage(&msg, NULL, 0, 0, PM_REMOVE) )
-        {
-           TranslateMessage(&msg);
-           DispatchMessage(&msg);
-        }
-        curr_ms = GetTickCount( );
-        sleep_millisecs = milliseconds_sleep_limit - curr_ms;
-        if( sleep_millisecs > max_sleep_ms)
-            sleep_millisecs = max_sleep_ms;
-        Sleep( sleep_millisecs);
-        curr_ms += sleep_millisecs;
-    }
+    LeaveCriticalSection(&PDC_cs);
+    Sleep(ms);
+    EnterCriticalSection(&PDC_cs);
 }
 
 const char *PDC_sysname(void)


### PR DESCRIPTION
Following up on issue #156, here's a proper way to fix the application hanging during a window resize or move.

I'm aware that WinGUI moved away from some sort of multi-threaded implementation several years back, but the synchronization code needed in this case is really pretty minimal and non-invasive. It uses a "critical section" object for synchronization. 

Before the window thread executes code that accesses or modifies sensitive shared variables, it requests ownership of the critical section object. The main thread owns the critical section except when it calls `PDC_napms()` or needs to make a Win32 API call that would *send* (as distinguished from "post") a message to the window and wait for it to be processed (the `SetWindowText()` call in `PDC_set_title()` is one instance, as is `SetWindowPos()` in `PDC_resize_screen()`). Before returning, the window procedure "leaves" the critical section. From my testing, the stability of this implementation seems pretty solid.

Features:

- Synchronization calls for the window thread are contained entirely in the window procedure, and only a few locations used by the main thread needed them.
- Low CPU footprint when idle. Because the main thread no longer has to handle the message queue, I was able to simplify `PDC_napms()` down to just a `Sleep()` call wrapped with `LeaveCriticalSection()`/`EnterCriticalSection()`. The window thread uses `GetMessage()` in its message loop, which blocks until a message is received.
- I removed or commented out up some superfluous code while I was at it, such as the `PDC_napms()` call in `PDC_check_key()` (the removal of which also improves the accuracy of `halfdelay()` - more on that later) and the `wndclass_has_been_registered` stuff in `set_up_window()` (more than one window is not currently supported). `PDC_bDone` is also no longer needed, and active instances of it have been commented out.

Some notes:

- The responsiveness of an application to resize events lags slightly. This can be improved by reducing the 50 ms checking interval in `wgetch()` to something like 1 or 5 ms. But this would affect the other PDCurses ports as well (unless wrapped with `#ifdef`s) and mess up `halfdelay()` on some systems (the precision of `Sleep()` is limited depending on the OS and/or hardware; `Sleep(1)` or `Sleep(5)` can result in a sleep of 15 ms or more).
- Bill-Gray's tweak in commit 0a511bfae15f4aa36917f37525676accd741f68f isn't needed anymore, but I kept it because combining multiple `KEY_RESIZE` events is a good idea that improves efficiency with applications with relatively "expensive" redraws.
- My code uses `_beginthreadex()` to create the window thread to ensure that C runtime library functions can be safely used. This should be fine with Visual C++, MinGW, MinGW-w64, Open Watcom, and later Borland C++ versions (I have tested with 32-bit MinGW-w64). But it may cause compatibility issues with early Borland C++ versions; my understanding is that Borland only offered `_beginthread()` and their own `_beginthreadNT()` to start with, then defined `_beginthreadex()` as a macro that resolves to `_beginthreadNT()` (around the time of Borland C++ 5.0), before finally properly implementing `_beginthreadex()`. My code waits on the handle returned by the function to catch premature thread termination, which makes using `_beginthread()` (or Borland's `_beginthreadNT()`) unsafe because it automatically closes the handle when the thread exits. Not sure about old versions of Digital Mars. I could probably implement this another way if supporting those earlier commercial compiler versions is still desired, but it would be less efficient.

